### PR TITLE
✨Feat: Input 합성 컴포넌트

### DIFF
--- a/src/components/input/ErrorMessage.tsx
+++ b/src/components/input/ErrorMessage.tsx
@@ -3,6 +3,8 @@ import { twMerge } from 'tailwind-merge';
 import type { ErrorMessageProps } from './types';
 
 const ErrorMessage = ({ children, className }: ErrorMessageProps) => {
+  if (!children) return null;
+
   return <p className={twMerge('text-md text-red', className)}>{children}</p>;
 };
 

--- a/src/components/input/ErrorMessage.tsx
+++ b/src/components/input/ErrorMessage.tsx
@@ -1,0 +1,9 @@
+import { twMerge } from 'tailwind-merge';
+
+import type { ErrorMessageProps } from './types';
+
+const ErrorMessage = ({ children, className }: ErrorMessageProps) => {
+  return <p className={twMerge('text-md text-red', className)}>{children}</p>;
+};
+
+export default ErrorMessage;

--- a/src/components/input/Field.tsx
+++ b/src/components/input/Field.tsx
@@ -1,0 +1,15 @@
+import { FileUpload, Text, TextArea } from './internals';
+import type { FieldProps } from './types';
+
+const compoentMap: Record<string, React.ElementType> = {
+  textarea: TextArea,
+  file: FileUpload,
+};
+
+const Field = ({ type = 'text', ...props }: FieldProps) => {
+  const Component = compoentMap[type] ?? Text;
+
+  return <Component type={type} {...props} />;
+};
+
+export default Field;

--- a/src/components/input/Field.tsx
+++ b/src/components/input/Field.tsx
@@ -1,13 +1,13 @@
 import { FileUpload, Text, TextArea } from './internals';
 import type { FieldProps } from './types';
 
-const compoentMap: Record<string, React.ElementType> = {
+const componentMap: Record<'textarea' | 'file', React.ElementType> = {
   textarea: TextArea,
   file: FileUpload,
 };
 
 const Field = ({ type = 'text', ...props }: FieldProps) => {
-  const Component = compoentMap[type] ?? Text;
+  const Component = type in componentMap ? componentMap[type as keyof typeof componentMap] : Text;
 
   return <Component type={type} {...props} />;
 };

--- a/src/components/input/Label.tsx
+++ b/src/components/input/Label.tsx
@@ -2,9 +2,9 @@ import { twMerge } from 'tailwind-merge';
 
 import type { LabelProps } from './types';
 
-const Label = ({ children, className, htmlFor }: LabelProps) => {
+const Label = ({ children, className, htmlFor, ...props }: LabelProps) => {
   return (
-    <label className={twMerge('text-lg text-gray-700', className)} htmlFor={htmlFor}>
+    <label className={twMerge('text-lg text-gray-700', className)} htmlFor={htmlFor} {...props}>
       {children}
     </label>
   );

--- a/src/components/input/Label.tsx
+++ b/src/components/input/Label.tsx
@@ -1,0 +1,9 @@
+import { twMerge } from 'tailwind-merge';
+
+import type { LabelProps } from './types';
+
+const Label = ({ children, className }: LabelProps) => {
+  return <label className={twMerge('text-lg text-gray-700', className)}>{children}</label>;
+};
+
+export default Label;

--- a/src/components/input/Label.tsx
+++ b/src/components/input/Label.tsx
@@ -2,8 +2,12 @@ import { twMerge } from 'tailwind-merge';
 
 import type { LabelProps } from './types';
 
-const Label = ({ children, className }: LabelProps) => {
-  return <label className={twMerge('text-lg text-gray-700', className)}>{children}</label>;
+const Label = ({ children, className, htmlFor }: LabelProps) => {
+  return (
+    <label className={twMerge('text-lg text-gray-700', className)} htmlFor={htmlFor}>
+      {children}
+    </label>
+  );
 };
 
 export default Label;

--- a/src/components/input/Root.tsx
+++ b/src/components/input/Root.tsx
@@ -1,4 +1,4 @@
-import React, { Children } from 'react';
+import { Children } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 import ErrorMessage from './ErrorMessage';
@@ -16,7 +16,7 @@ const Root = ({ children, className }: RootProps) => {
   ];
 
   return (
-    <div className={twMerge('flex flex-col gap-8', className)}>
+    <div className={twMerge('flex flex-col gap-8', className)} role='group'>
       {label}
       {field}
       {errorMessage}

--- a/src/components/input/Root.tsx
+++ b/src/components/input/Root.tsx
@@ -1,0 +1,27 @@
+import React, { Children } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import ErrorMessage from './ErrorMessage';
+import Field from './Field';
+import Label from './Label';
+import type { RootProps } from './types';
+
+const Root = ({ children, className }: RootProps) => {
+  const _children = Children.toArray(children) as React.ReactElement[];
+
+  const [label, field, errorMessage] = [
+    _children.find((child) => child.type === Label),
+    _children.find((child) => child.type === Field),
+    _children.find((child) => child.type === ErrorMessage),
+  ];
+
+  return (
+    <div className={twMerge('flex flex-col gap-8', className)}>
+      {label}
+      {field}
+      {errorMessage}
+    </div>
+  );
+};
+
+export default Root;

--- a/src/components/input/index.ts
+++ b/src/components/input/index.ts
@@ -1,0 +1,71 @@
+import ErrorMessage from './ErrorMessage';
+import Field from './Field';
+import Label from './Label';
+import Root from './Root';
+
+/**
+ * Input 컴포넌트 모듈입니다.
+ *
+ * 이 모듈은 다양한 입력 폼 요소들을 조합할 수 있는 합성 컴포넌트 구조를 제공합니다.
+ * 아래의 서브 컴포넌트들을 조합하여 로그인, 회원가입, 댓글 등 다양한 입력 폼을 구성할 수 있습니다.
+ *
+ * 각 컴포넌트는 `className`을 통해 Tailwind 기반의 스타일 확장이 가능합니다.
+ *
+ * @example
+ * ```tsx
+ * <Input.Root>
+ *   <Input.Label>이메일</Input.Label>
+ *   <Input.Field type="email" />
+ *   <Input.ErrorMessage>이메일을 입력해주세요</Input.ErrorMessage>
+ * </Input.Root>
+ * ```
+ */
+const Input = {
+  /**
+   * 입력 폼의 최상위 래퍼 컴포넌트입니다.
+   *
+   * @param {string} [className] - 입력 영역 전체를 감싸는 래퍼 스타일을 지정할 수 있습니다.
+   * @param {React.ReactNode} children - 내부에 포함할 Label, Field, ErrorMessage 등을 자식으로 전달합니다.
+   *
+   * @remarks
+   * - `children`의 순서는 무관하지만, `Label → Field → ErrorMessage` 순서로 자동 정렬됩니다.
+   * - 내부 정렬은 수직 정렬(`flex-col`, `gap`)로 구성되어 있습니다.
+   */
+  Root,
+
+  /**
+   * 입력 필드와 연결되는 라벨 컴포넌트입니다.
+   *
+   * @param {string} [className] - 텍스트 스타일을 지정할 수 있습니다.
+   * @param {React.ReactNode} children - 라벨에 표시할 텍스트 또는 요소입니다.
+   *
+   * @remarks
+   * - `htmlFor` 속성을 사용해 `<Input.Field>`의 `id`와 연결할 수 있습니다.
+   */
+  Label,
+
+  /**
+   * 실제 사용자 입력을 받는 필드입니다.
+   *
+   * @param {string} type - 기본값은 `'text'`, `textarea`, `file` 등 지원됩니다.
+   * @param {string} [className] - 인풋 영역의 스타일을 지정할 수 있습니다.
+   * @param {...rest} 기타 HTML 속성들 - `placeholder`, `autoComplete`, `onChange` 등 기본 input 속성을 전달할 수 있습니다.
+   *
+   * @remarks
+   * - `type="textarea"`이면 `<textarea>`, `type="file"`이면 파일 업로드 input, 그 외는 `<input>`으로 렌더링됩니다.
+   */
+  Field,
+
+  /**
+   * 입력값 오류 메시지를 표시하는 영역입니다.
+   *
+   * @param {string} [className] - 오류 메시지 스타일 지정
+   * @param {React.ReactNode} children - 오류 메시지 텍스트 또는 요소
+   *
+   * @remarks
+   * - 에러가 발생한 필드 하단에 자동 정렬되어 표시됩니다.
+   */
+  ErrorMessage,
+};
+
+export default Input;

--- a/src/components/input/internals/FileUpload.tsx
+++ b/src/components/input/internals/FileUpload.tsx
@@ -1,0 +1,18 @@
+import { twMerge } from 'tailwind-merge';
+
+import type { FileUploadProps } from '@/components/input/types';
+
+const FileUpload = ({ className, type, ...props }: FileUploadProps) => {
+  return (
+    <input
+      className={twMerge(
+        'block w-full text-sm text-gray-900 file:mr-4 file:rounded-md file:border-0 file:bg-gray-100 file:px-4 file:py-2 file:text-sm file:font-medium file:text-gray-700 hover:file:bg-gray-200',
+        className,
+      )}
+      type={type}
+      {...props}
+    />
+  );
+};
+
+export default FileUpload;

--- a/src/components/input/internals/FileUpload.tsx
+++ b/src/components/input/internals/FileUpload.tsx
@@ -2,8 +2,8 @@ import { twMerge } from 'tailwind-merge';
 
 import type { FileUploadProps } from '@/components/input/types';
 
-const FileUpload = ({ className, type, ref, ...props }: FileUploadProps) => {
-  return <input ref={ref} className={twMerge('sr-only', className)} type={type} {...props} />;
+const FileUpload = ({ className, ref, ...props }: FileUploadProps) => {
+  return <input ref={ref} className={twMerge('sr-only', className)} {...props} />;
 };
 
 export default FileUpload;

--- a/src/components/input/internals/FileUpload.tsx
+++ b/src/components/input/internals/FileUpload.tsx
@@ -3,16 +3,7 @@ import { twMerge } from 'tailwind-merge';
 import type { FileUploadProps } from '@/components/input/types';
 
 const FileUpload = ({ className, type, ...props }: FileUploadProps) => {
-  return (
-    <input
-      className={twMerge(
-        'block w-full text-sm text-gray-900 file:mr-4 file:rounded-md file:border-0 file:bg-gray-100 file:px-4 file:py-2 file:text-sm file:font-medium file:text-gray-700 hover:file:bg-gray-200',
-        className,
-      )}
-      type={type}
-      {...props}
-    />
-  );
+  return <input className={twMerge('sr-only', className)} type={type} {...props} />;
 };
 
 export default FileUpload;

--- a/src/components/input/internals/FileUpload.tsx
+++ b/src/components/input/internals/FileUpload.tsx
@@ -2,8 +2,8 @@ import { twMerge } from 'tailwind-merge';
 
 import type { FileUploadProps } from '@/components/input/types';
 
-const FileUpload = ({ className, type, ...props }: FileUploadProps) => {
-  return <input className={twMerge('sr-only', className)} type={type} {...props} />;
+const FileUpload = ({ className, type, ref, ...props }: FileUploadProps) => {
+  return <input ref={ref} className={twMerge('sr-only', className)} type={type} {...props} />;
 };
 
 export default FileUpload;

--- a/src/components/input/internals/Text.tsx
+++ b/src/components/input/internals/Text.tsx
@@ -1,0 +1,18 @@
+import { twMerge } from 'tailwind-merge';
+
+import type { TextInputProps } from '@/components/input/types';
+
+const Text = ({ type = 'text', className, ...props }: TextInputProps) => {
+  return (
+    <input
+      className={twMerge(
+        'block h-50 w-full rounded-lg border border-gray-300 px-16 py-12 text-lg text-gray-700 placeholder-gray-400 transition-all duration-150 ease-in-out focus:border-transparent focus:ring-2 focus:ring-capybara focus:outline-none',
+        className,
+      )}
+      type={type}
+      {...props}
+    />
+  );
+};
+
+export default Text;

--- a/src/components/input/internals/Text.tsx
+++ b/src/components/input/internals/Text.tsx
@@ -2,16 +2,30 @@ import { twMerge } from 'tailwind-merge';
 
 import type { TextInputProps } from '@/components/input/types';
 
-const Text = ({ type = 'text', className, ...props }: TextInputProps) => {
+const Text = ({ type = 'text', className, leftIcon, rightIcon, isInvalid, ref, ...props }: TextInputProps) => {
   return (
-    <input
-      className={twMerge(
-        'block h-50 w-full rounded-lg border border-gray-300 px-16 py-12 text-lg text-gray-700 placeholder-gray-400 transition-all duration-150 ease-in-out focus:border-transparent focus:ring-2 focus:ring-capybara focus:outline-none',
-        className,
+    <div className='relative w-full'>
+      {leftIcon && (
+        <div className='absolute top-1/2 left-16 flex -translate-y-1/2 items-center justify-center'>{leftIcon}</div>
       )}
-      type={type}
-      {...props}
-    />
+
+      <input
+        ref={ref}
+        className={twMerge(
+          'block h-50 w-full rounded-lg border px-16 py-12 text-lg text-gray-700 placeholder-gray-400 transition-all duration-150 ease-in-out focus:border-transparent focus:ring-2 focus:ring-capybara focus:outline-none',
+          leftIcon && 'pl-45',
+          rightIcon && 'pr-45',
+          isInvalid ? 'border-red-500 focus:ring-red-500' : 'border-gray-300',
+          className,
+        )}
+        type={type}
+        {...props}
+      />
+
+      {rightIcon && (
+        <div className='absolute top-1/2 right-16 flex -translate-y-1/2 items-center justify-center'>{rightIcon}</div>
+      )}
+    </div>
   );
 };
 

--- a/src/components/input/internals/TextArea.tsx
+++ b/src/components/input/internals/TextArea.tsx
@@ -2,7 +2,7 @@ import { twMerge } from 'tailwind-merge';
 
 import type { TextAreaProps } from '@/components/input/types';
 
-const TextArea = ({ className, ...props }: TextAreaProps) => {
+const TextArea = ({ className, type: _ignored, ...props }: TextAreaProps) => {
   return (
     <textarea
       className={twMerge(

--- a/src/components/input/internals/TextArea.tsx
+++ b/src/components/input/internals/TextArea.tsx
@@ -2,14 +2,13 @@ import { twMerge } from 'tailwind-merge';
 
 import type { TextAreaProps } from '@/components/input/types';
 
-const TextArea = ({ name, className, ...props }: TextAreaProps) => {
+const TextArea = ({ className, ...props }: TextAreaProps) => {
   return (
     <textarea
       className={twMerge(
-        'focus:ring-primary block w-full resize-none rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:ring-2 focus:outline-none',
+        'block h-110 w-full resize-none rounded-md border border-gray-300 p-16 text-lg text-gray-700 placeholder-gray-400 transition-all duration-150 ease-in-out focus:border-transparent focus:ring-2 focus:ring-capybara focus:outline-none',
         className,
       )}
-      name={name}
       {...props}
     />
   );

--- a/src/components/input/internals/TextArea.tsx
+++ b/src/components/input/internals/TextArea.tsx
@@ -1,0 +1,18 @@
+import { twMerge } from 'tailwind-merge';
+
+import type { TextAreaProps } from '@/components/input/types';
+
+const TextArea = ({ name, className, ...props }: TextAreaProps) => {
+  return (
+    <textarea
+      className={twMerge(
+        'focus:ring-primary block w-full resize-none rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:ring-2 focus:outline-none',
+        className,
+      )}
+      name={name}
+      {...props}
+    />
+  );
+};
+
+export default TextArea;

--- a/src/components/input/internals/index.ts
+++ b/src/components/input/internals/index.ts
@@ -1,0 +1,3 @@
+export { default as FileUpload } from './FileUpload';
+export { default as Text } from './Text';
+export { default as TextArea } from './TextArea';

--- a/src/components/input/types/index.ts
+++ b/src/components/input/types/index.ts
@@ -9,6 +9,10 @@ export interface ErrorMessageProps {
 
 export interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   type: string;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+  isInvalid?: boolean;
+  ref?: React.Ref<HTMLInputElement>;
 }
 
 export interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'autoComplete'> {

--- a/src/components/input/types/index.ts
+++ b/src/components/input/types/index.ts
@@ -17,6 +17,7 @@ export interface TextInputProps extends React.InputHTMLAttributes<HTMLInputEleme
 
 export interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'autoComplete'> {
   type: 'textarea';
+  ref?: React.Ref<HTMLTextAreaElement>;
 }
 
 export interface FileUploadProps extends React.InputHTMLAttributes<HTMLInputElement> {

--- a/src/components/input/types/index.ts
+++ b/src/components/input/types/index.ts
@@ -8,7 +8,7 @@ export interface ErrorMessageProps {
 }
 
 export interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  type: string;
+  type?: Exclude<string, 'file' | 'textarea'>;
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
   isInvalid?: boolean;

--- a/src/components/input/types/index.ts
+++ b/src/components/input/types/index.ts
@@ -4,7 +4,7 @@ export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> 
 
 export interface ErrorMessageProps {
   className?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
 export interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -21,6 +21,7 @@ export interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTex
 
 export interface FileUploadProps extends React.InputHTMLAttributes<HTMLInputElement> {
   type: 'file';
+  ref?: React.Ref<HTMLInputElement>;
 }
 
 export type FieldProps = TextInputProps | TextAreaProps | FileUploadProps;

--- a/src/components/input/types/index.ts
+++ b/src/components/input/types/index.ts
@@ -1,32 +1,112 @@
+/**
+ * `<label>` 요소에 대한 속성 정의입니다.
+ * React의 기본 `<label>` 속성을 모두 확장하며, Input 컴포넌트의 라벨로 사용됩니다.
+ */
 export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  /**
+   * 연결할 input 요소의 id입니다. 필수 입력입니다.
+   */
+  htmlFor: string;
+  /**
+   * 라벨 안에 렌더링될 내용입니다.
+   * 일반적으로 문자열 또는 React 엘리먼트를 사용하며, 관련 입력 필드를 설명하는 텍스트입니다.
+   */
   children: React.ReactNode;
 }
 
+/**
+ * 입력 필드 아래에 표시되는 에러 메시지 컴포넌트의 속성입니다.
+ * 입력 유효성 검사 실패 시 사용자에게 피드백을 제공하는 역할을 합니다.
+ */
 export interface ErrorMessageProps {
+  /**
+   * 에러 메시지의 스타일을 커스터마이징하기 위한 클래스 이름입니다.
+   */
   className?: string;
+  /**
+   * 렌더링할 에러 메시지 내용입니다.
+   * 이 값이 없으면 에러 메시지는 렌더링되지 않습니다.
+   */
   children?: React.ReactNode;
 }
 
+/**
+ * 일반적인 `<input>` 요소에 사용되는 속성입니다.
+ * `type`이 `'file'` 또는 `'textarea'`가 아닌 경우에만 사용됩니다.
+ */
 export interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  /**
+   * 입력 타입입니다. 예: `'text'`, `'password'`, `'email'` 등.
+   * `'file'`과 `'textarea'`는 이 타입에서 제외되며, 각각 별도의 컴포넌트로 처리됩니다.
+   */
   type?: Exclude<string, 'file' | 'textarea'>;
+  /**
+   * 입력 필드 왼쪽에 렌더링할 아이콘이나 커스텀 요소입니다.
+   */
   leftIcon?: React.ReactNode;
+  /**
+   * 입력 필드 오른쪽에 렌더링할 아이콘이나 커스텀 요소입니다.
+   * 보통 비밀번호 보기 토글 버튼이나 검색 버튼 등에 사용됩니다.
+   */
   rightIcon?: React.ReactNode;
+  /**
+   * 유효하지 않은 입력 상태를 나타냅니다.
+   * 주로 스타일링(예: 빨간 테두리)을 위해 사용됩니다.
+   */
   isInvalid?: boolean;
+  /**
+   * 내부 `<input>` 요소에 전달될 참조 객체입니다.
+   * imperative하게 포커스, 값 접근 등을 할 때 사용됩니다.
+   */
   ref?: React.Ref<HTMLInputElement>;
 }
 
+/**
+ * `<textarea>` 요소에 대한 속성입니다.
+ * `type` 속성은 DOM에는 전달되지 않으며, 컴포넌트 내부 분기 처리용으로만 사용됩니다.
+ */
 export interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'autoComplete'> {
+  /**
+   * 내부 로직에서 `FieldProps` 타입 분기를 위해 사용됩니다.
+   * 실제로 `<textarea>` 태그에는 전달되지 않습니다.
+   */
   type: 'textarea';
+  /**
+   * 내부 `<textarea>` 요소에 전달될 참조 객체입니다.
+   */
   ref?: React.Ref<HTMLTextAreaElement>;
 }
 
+/**
+ * 파일 업로드용 `<input type="file">` 요소의 속성입니다.
+ * `type`은 항상 `'file'`이며, 실제 DOM에 직접 명시됩니다.
+ */
 export interface FileUploadProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  /**
+   * 내부 로직에서 `FieldProps` 타입 분기를 위해 사용됩니다.
+   * 실제 `<input>` 태그에는 `type="file"`로 고정되어 들어갑니다.
+   */
   type: 'file';
+  /**
+   * 내부 `<input>` 요소에 전달될 참조 객체입니다.
+   */
   ref?: React.Ref<HTMLInputElement>;
 }
 
+/**
+ * Input.Field에서 사용 가능한 모든 필드 타입의 유니언입니다.
+ * `type` 값에 따라 Text, TextArea, FileUpload 중 적절한 컴포넌트를 선택합니다.
+ */
 export type FieldProps = TextInputProps | TextAreaProps | FileUploadProps;
 
+/**
+ * Input 컴포넌트의 Root 영역에 대한 속성입니다.
+ * 보통 label, input, errorMessage를 하나로 묶는 컨테이너 역할을 합니다.
+ */
 export interface RootProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Root 컴포넌트 안에 들어갈 모든 자식 요소입니다.
+   * 일반적으로 Label, Field, ErrorMessage 컴포넌트가 포함됩니다.
+   */
   children: React.ReactNode;
 }

--- a/src/components/input/types/index.ts
+++ b/src/components/input/types/index.ts
@@ -13,7 +13,6 @@ export interface TextInputProps extends React.InputHTMLAttributes<HTMLInputEleme
 
 export interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'autoComplete'> {
   type: 'textarea';
-  name: string;
 }
 
 export interface FileUploadProps extends React.InputHTMLAttributes<HTMLInputElement> {

--- a/src/components/input/types/index.ts
+++ b/src/components/input/types/index.ts
@@ -1,0 +1,27 @@
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  children: React.ReactNode;
+}
+
+export interface ErrorMessageProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  type: string;
+}
+
+export interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'autoComplete'> {
+  type: 'textarea';
+  name: string;
+}
+
+export interface FileUploadProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  type: 'file';
+}
+
+export type FieldProps = TextInputProps | TextAreaProps | FileUploadProps;
+
+export interface RootProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -58,5 +58,6 @@
 
   html {
     font-family: 'Pretendard', system-ui, sans-serif;
+    word-break: keep-all;
   }
 }


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- #84 

## ✨ 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->

- Input 합성 컴포넌트 구현

## 📌 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->

- Input 합성 컴포넌트를 크게 `Root`, `Label`, `Field`, `ErrerMessage`로 나눴습니다.
- `Field` 에서는 크게 3가지 분기로 나눴습니다.
    1. `<textarea>`를 담당하는 `TextArea` 
        - `<Input.Field type='textarea'/>` 라고 입력해야함
    2. `<input type="file" />`를 담당하는 `FileUpload`
        - `<Input.Field type='file'/>` 라고 입력해야함
    3. 그외 모든 input을 담당할 `Text`

- `Text` 일때는 좌, 우 아이콘을 추가할 수 있게 구현했고, 기능도 더해서 사용 가능합니다.
- `ErrorMessage`는 선언하고 에러메세지가 없을 경우 null로 설정해서 영역을 차지하지 않게 구현했습니다.

- Tailwind CSS에 단어 단위로 줄바꿈할 수 있도록 추가했습니다.

## ✅ 체크리스트

<!-- 체크리스트 내용을 수정하고 싶으면 회의 때 얘기부탁드려요. -->

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다.
  - [x] 구현 기간에 맞는 이슈에서 서브이슈로 등록했습니다.
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
  - [x] PR 사이드 탭에서는 Projects을 등록 하지않았습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)

#### 에러가 있을 때 디자인

<img width="1067" alt="image" src="https://github.com/user-attachments/assets/a72bf238-ce02-48ac-b863-639d4783c572" />

> 아이콘은 저기 위치할 수 있다라고 알려주기 위해 추가한 것이고, 선언하지 않으면 사용되지않고 영역도 잡아먹지 않습니다.

#### 에러가 없을 때 디자인

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/f711a63e-edac-4516-ba9b-1785ddf2765a" />

> focus일때 사진을 안찍었는데 카피바라 색이 나오도록 했고, 포커스 될때까지 살짝의 transition을 줬습니다.

## ❓무슨 문제가 발생했나요 ?

> 가볍게 생각하고 시도한 제가 밉습니다

## 💬 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->

@pappaya109 @kjhyun0830 
```tsx
<Input.Root>
  <Input.Label
    className='flex h-76 w-76 cursor-pointer items-center justify-center rounded-md bg-[#F5F5F5] transition-colors hover:bg-gray-200'
    htmlFor='fileUpload'
  >
    <AddIcon />
  </Input.Label>
  <Input.Field id='fileUpload' name='fileUpload' type='file' />
</Input.Root>
```
FileUpload 부분은 input의 css를 제거하고 label로 클릭되도록 구현한다고 합니다. 그래서 input에 `sr-only`를 지정해뒀습니다. 
그래서 파일 업로드 부분에서 가져다가 사용할때는 위와같은 예시로 label에 스타일 값을 주시면 됩니다.
(위 코드는 수진님 부분 예시입니다.)

@leeetaesik 
```tsx
<Input.Root>
  <Input.Label className="sr-only">검색어</Input.Label> // 생략하셔도 되고 label을 사용하지 않더라도 시멘틱태그를 사용을 고려하신다면 참고해주세요 
  <Input.Field
    type="text"
    value={query}
    onChange={(e) => setQuery(e.target.value)}
    placeholder="검색어를 입력하세요"
    leftIcon={<Search/>} // 검색아이콘을 버튼으로 사용안하고 아이콘만 사용할 때의 예시
    rightIcon={
      <button type="button" onClick={handleSearch}>
        <Search size={20} />
      </button> // 검색아이콘을 버튼으로 사용히고 싶을 때 사용 예시
    }
  />
</Input.Root>
```
검색은 React-Hook-Form도 사용하는 것이 아니여서 위와 같은 예시코드로 사용하면 될 것 같습니다. 그리고 검색은 ref 방식이 아닌 것 같아 구현하실때 debounce에 관해서 찾아보시면 좋을 것 같아요.

@pappaya109 
```tsx
<Input.Root>
  <Input.Field name='comment' placeholder='댓글을 입력해주세요' type='textarea' />
</Input.Root>
```
댓글용 input을 사용하기 위해서는 `type='textarea'`를 선언해주면 됩니다.(모달에 맞게 디자인을 해두긴했어요..!)
버튼은 아마 Field 아래에 `<botton>` 태그로 absolute 사용해서 위치를 지정해 주셔야 할 것같아요..!
그리고 개인적으로 dm 보냈긴 했지만 name 태그 or id 태그를 꼭 사용해주세요! 

사용예시를 만들어 뒀지만 이해가 안가는 부분이 있으시면 코드리뷰나 dm으로 불러주시면 바로 알려드리겠습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 다양한 입력 폼(로그인, 회원가입, 댓글 등) 구성을 위한 Input 컴포넌트 세트가 추가되었습니다. Label, Field, ErrorMessage, Root 등으로 구성되어 손쉽게 조합 및 스타일 확장이 가능합니다.
  - 텍스트, 파일 업로드, 텍스트에어리어 등 다양한 입력 타입과 에러 메시지, 아이콘 표시, 라벨 연결 기능을 지원합니다.

- **스타일**
  - 전체 텍스트의 줄바꿈 시 단어가 분리되지 않도록 CSS(word-break: keep-all)가 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->