### PR TITLE
✨Feat: 내 대시보드 페이지 데이터 불러오기

### DIFF
--- a/src/apis/invitation.ts
+++ b/src/apis/invitation.ts
@@ -1,0 +1,21 @@
+import { INVITATION_ENDPOINTS } from '@/constants/paths';
+import type { Invitation, InvitationList, InvitationListParams, RespondInvitationParams } from '@/schemas/invitation';
+
+import { requestGet, requestPut } from './base/request';
+
+/**
+ * @description 초대 목록을 조회합니다.
+ * @param params 쿼리 파라미터 (cursorId, title, size)
+ */
+export const getInvitationList = async (params: InvitationListParams) => {
+  return requestGet<InvitationList>(INVITATION_ENDPOINTS.LIST, { params });
+};
+
+/**
+ * @description 초대에 응답합니다.
+ * @param dashboardId 수정할 대시보드 ID
+ * @param dashboardInput 수정할 대시보드 데이터
+ */
+export const respondInvitation = async (invitationId: number, respond: RespondInvitationParams) => {
+  return requestPut<Invitation, RespondInvitationParams>(`${INVITATION_ENDPOINTS.RESPOND}/${invitationId}`, respond);
+};

--- a/src/apis/invitation.ts
+++ b/src/apis/invitation.ts
@@ -17,5 +17,5 @@ export const getInvitationList = async (params: InvitationListParams) => {
  * @param dashboardInput 수정할 대시보드 데이터
  */
 export const respondInvitation = async (invitationId: number, respond: RespondInvitationParams) => {
-  return requestPut<Invitation, RespondInvitationParams>(`${INVITATION_ENDPOINTS.RESPOND}/${invitationId}`, respond);
+  return requestPut<Invitation, RespondInvitationParams>(INVITATION_ENDPOINTS.RESPOND(String(invitationId)), respond);
 };

--- a/src/components/dashboardItem/index.tsx
+++ b/src/components/dashboardItem/index.tsx
@@ -1,0 +1,44 @@
+import { Link } from 'react-router-dom';
+
+import ChevronIcon from '@/assets/icons/ChevronIcon';
+import CrownIcon from '@/assets/icons/CrownIcon';
+import DotIcon from '@/assets/icons/DotIcon';
+import Button from '@/components/common/button';
+import { getDashboardDetailPath } from '@/constants/paths';
+import type { Dashboard } from '@/schemas/dashboard';
+
+/**
+ * 대시보드 목록에서 각 대시보드를 나타내는 항목 컴포넌트.
+ * 클릭 시 해당 대시보드의 상세 페이지로 이동합니다.
+ *
+ * @param {string} color - 대시보드 점 색상
+ * @param {boolean} createdByMe - 현재 로그인한 사용자가 생성한 대시보드인지 여부
+ * @param {string} title - 대시보드의 제목
+ * @param {number} id - 대시보드의 고유 ID
+ */
+
+const DashboardItem = ({
+  color,
+  createdByMe,
+  title,
+  id,
+}: Pick<Dashboard, 'color' | 'createdByMe' | 'id' | 'title'>) => {
+  const path = getDashboardDetailPath(String(id));
+  return (
+    <Button
+      as={Link}
+      className='h-58 w-full justify-between gap-12 rounded-lg px-20 text-md font-semibold text-gray-700 tablet:h-68 tablet:text-lg'
+      size='none'
+      to={path}
+      variant='outlined'
+    >
+      <div className='flex items-center'>
+        <DotIcon className='mr-12 pc:mr-16' color={color} size={8} />
+        {title}
+        {createdByMe && <CrownIcon className='ml-4 w-15 tablet:ml-6 tablet:w-18 pc:ml-8 pc:w-20' />}
+      </div>
+      <ChevronIcon />
+    </Button>
+  );
+};
+export default DashboardItem;

--- a/src/components/invitationItem/index.tsx
+++ b/src/components/invitationItem/index.tsx
@@ -1,0 +1,34 @@
+import Button from '@/components/common/button';
+
+import type { InvitationItemProps } from './types';
+
+/**
+ * 초대받은 대시보드 목록의 개별 항목을 렌더링하는 컴포넌트입니다.
+ * 각 항목은 대시보드 이름, 초대자 정보, 그리고 초대를 수락하거나 거절하는 버튼을 포함합니다.
+ *
+ * @param {string} dashboardTitle - 초대받은 대시보드의 제목입니다.
+ * @param {string} inviterNickname - 초대를 보낸 사용자의 닉네임입니다.
+ */
+const InvitationItem = ({ dashboardTitle, inviterNickname }: InvitationItemProps) => {
+  return (
+    <>
+      <div className='flex gap-24 text-md font-normal tablet:w-3/10 tablet:text-lg'>
+        <span className='w-38 text-gray-400 tablet:hidden'>이름</span>
+        <span>{dashboardTitle}</span>
+      </div>
+      <div className='flex gap-24 text-md font-normal tablet:w-2/10 tablet:text-lg'>
+        <span className='w-38 text-gray-400 tablet:hidden'>초대자</span>
+        <span>{inviterNickname}</span>
+      </div>
+      <div className='mt-14 flex justify-center gap-10 tablet:mt-0 tablet:w-4/10'>
+        <Button className='w-full tablet:w-72 tablet:text-md pc:w-84' size='sm'>
+          수락
+        </Button>
+        <Button className='w-full tablet:w-72 tablet:text-md pc:w-84' size='sm' variant='outlined'>
+          거절
+        </Button>
+      </div>
+    </>
+  );
+};
+export default InvitationItem;

--- a/src/components/invitationItem/types/index.ts
+++ b/src/components/invitationItem/types/index.ts
@@ -1,0 +1,6 @@
+import type { Invitation } from '@/schemas/invitation';
+
+export interface InvitationItemProps {
+  dashboardTitle: Invitation['dashboard']['title'];
+  inviterNickname: Invitation['inviter']['nickname'];
+}

--- a/src/loaders/dashboard/listLoader.ts
+++ b/src/loaders/dashboard/listLoader.ts
@@ -1,3 +1,35 @@
+import { getDashboardList } from '@/apis/dashboard';
+import { getInvitationList } from '@/apis/invitation';
+import { dashboardListResponseSchema } from '@/schemas/dashboard';
+import { invitationListSchema } from '@/schemas/invitation';
+import handleLoaderError from '@/utils/error/handleLoaderError';
+
 export const loader = async () => {
-  return null;
+  try {
+    const results = await Promise.allSettled([
+      getDashboardList({ navigationMethod: 'pagination', size: 5 }),
+      getInvitationList({}),
+    ]);
+
+    const rejectedPromises = results.filter((result) => result.status === 'rejected');
+
+    if (rejectedPromises.length > 0) {
+      rejectedPromises.forEach((promise, index) => {
+        const apiName = index === 0 ? 'getDashboardList' : 'getInvitationList';
+        console.error(`🩺 ${apiName} API 호출 실패:`, (promise as PromiseRejectedResult).reason);
+      });
+      // 첫 번째 에러를 ErrorBoundary로 던져서 UI를 중단시킵니다.
+      throw rejectedPromises[0].reason;
+    }
+
+    const rawDashboardList = (results[0] as PromiseFulfilledResult<unknown>).value;
+    const rawInvitationList = (results[1] as PromiseFulfilledResult<unknown>).value;
+
+    const dashboardList = dashboardListResponseSchema.parse(rawDashboardList);
+    const invitationList = invitationListSchema.parse(rawInvitationList);
+
+    return { dashboardList, invitationList };
+  } catch (error) {
+    return handleLoaderError(error);
+  }
 };

--- a/src/loaders/dashboard/listLoader.ts
+++ b/src/loaders/dashboard/listLoader.ts
@@ -4,7 +4,9 @@ import { dashboardListResponseSchema } from '@/schemas/dashboard';
 import { invitationListSchema } from '@/schemas/invitation';
 import handleLoaderError from '@/utils/error/handleLoaderError';
 
-export const loader = async () => {
+import type { DashboardListLoaderData } from './types';
+
+export const loader = async (): Promise<DashboardListLoaderData> => {
   try {
     const results = await Promise.allSettled([
       getDashboardList({ navigationMethod: 'pagination', size: 5 }),

--- a/src/loaders/dashboard/types/index.ts
+++ b/src/loaders/dashboard/types/index.ts
@@ -1,4 +1,5 @@
-import type { Dashboard } from '@/schemas/dashboard';
+import type { Dashboard, DashboardListData } from '@/schemas/dashboard';
+import type { InvitationList } from '@/schemas/invitation';
 import type { MemberListData } from '@/schemas/member';
 
 /**
@@ -9,4 +10,14 @@ import type { MemberListData } from '@/schemas/member';
 export interface DashboardDetailLoaderData {
   dashboardDetail: Dashboard;
   memberListResponse: MemberListData;
+}
+
+/**
+ * @description 나의 대시보드 페이지 로더(listLoader)가 반환하는 데이터의 타입입니다.
+ * @property {import('@/schemas/dashboard').DashboardListData} dashboardList - 대시보드 리스트 정보입니다.
+ * @property {import('@/schemas/invitation').InvitationList} invitationList - 내가 초대 받은 리스트 응답 데이터입니다.
+ */
+export interface DashboardListLoaderData {
+  dashboardList: DashboardListData;
+  invitationList: InvitationList;
 }

--- a/src/pages/dashboards/DashboardList.tsx
+++ b/src/pages/dashboards/DashboardList.tsx
@@ -1,11 +1,9 @@
 import { useState } from 'react';
-import { Link, useLoaderData } from 'react-router-dom';
+import { useLoaderData } from 'react-router-dom';
 
 import AddIcon from '@/assets/icons/AddIcon';
-import ChevronIcon from '@/assets/icons/ChevronIcon';
-import CrownIcon from '@/assets/icons/CrownIcon';
-import DotIcon from '@/assets/icons/DotIcon';
 import Button from '@/components/common/button';
+import DashboardItem from '@/components/dashboardItem';
 import Pagination from '@/components/pagination';
 import type { DashboardListLoaderData } from '@/loaders/dashboard/types';
 import type { Dashboard } from '@/schemas/dashboard';
@@ -32,22 +30,13 @@ const DashboardList = () => {
                 새로운 대시보드 <AddIcon className='size-20 rounded-sm bg-cream p-5 tablet:size-22 tablet:p-6' />
               </Button>
             </li>
-            <li>
-              <Button
-                as={Link}
-                className='h-58 w-full justify-between gap-12 rounded-lg px-20 text-md font-semibold text-gray-700 tablet:h-68 tablet:text-lg'
-                size='none'
-                to='./'
-                variant='outlined'
-              >
-                <div className='flex items-center'>
-                  <DotIcon className='mr-12 pc:mr-16' color='var(--color-green)' size={8} />
-                  비브리지
-                  <CrownIcon className='ml-4 w-15 tablet:ml-6 tablet:w-18 pc:ml-8 pc:w-20' />
-                </div>
-                <ChevronIcon />
-              </Button>
-            </li>
+            {dashboardList.map((item) => {
+              return (
+                <li key={item.id}>
+                  <DashboardItem {...item} />
+                </li>
+              );
+            })}
           </ul>
 
           <div className='mt-16 mb-24 flex items-center justify-end tablet:mb-48'>

--- a/src/pages/dashboards/DashboardList.tsx
+++ b/src/pages/dashboards/DashboardList.tsx
@@ -4,6 +4,7 @@ import { useLoaderData } from 'react-router-dom';
 import AddIcon from '@/assets/icons/AddIcon';
 import Button from '@/components/common/button';
 import DashboardItem from '@/components/dashboardItem';
+import InvitationItem from '@/components/invitationItem';
 import Pagination from '@/components/pagination';
 import type { DashboardListLoaderData } from '@/loaders/dashboard/types';
 import type { Dashboard } from '@/schemas/dashboard';
@@ -30,13 +31,11 @@ const DashboardList = () => {
                 새로운 대시보드 <AddIcon className='size-20 rounded-sm bg-cream p-5 tablet:size-22 tablet:p-6' />
               </Button>
             </li>
-            {dashboardList.map((item) => {
-              return (
-                <li key={item.id}>
-                  <DashboardItem {...item} />
-                </li>
-              );
-            })}
+            {dashboardList.map((item) => (
+              <li key={item.id}>
+                <DashboardItem {...item} />
+              </li>
+            ))}
           </ul>
 
           <div className='mt-16 mb-24 flex items-center justify-end tablet:mb-48'>
@@ -55,24 +54,14 @@ const DashboardList = () => {
               <span className='w-2/10'>초대자</span>
               <span className='w-4/10 text-center'>수락 여부</span>
             </li>
-            <li className='border-b border-gray-200 px-16 py-14 tablet:flex tablet:items-center tablet:px-28 tablet:py-22 pc:px-76'>
-              <div className='flex gap-24 text-md font-normal tablet:w-3/10 tablet:text-lg'>
-                <span className='w-38 text-gray-400 tablet:hidden'>이름</span>
-                <span>프로덕트 디자인</span>
-              </div>
-              <div className='flex gap-24 text-md font-normal tablet:w-2/10 tablet:text-lg'>
-                <span className='w-38 text-gray-400 tablet:hidden'>초대자</span>
-                <span>손동희</span>
-              </div>
-              <div className='mt-14 flex justify-center gap-10 tablet:mt-0 tablet:w-4/10'>
-                <Button className='w-full tablet:w-72 tablet:text-md pc:w-84' size='sm'>
-                  수락
-                </Button>
-                <Button className='w-full tablet:w-72 tablet:text-md pc:w-84' size='sm' variant='outlined'>
-                  거절
-                </Button>
-              </div>
-            </li>
+            {invitationList.map((item) => (
+              <li
+                key={item.id}
+                className='border-b border-gray-200 px-16 py-14 tablet:flex tablet:items-center tablet:px-28 tablet:py-22 pc:px-76'
+              >
+                <InvitationItem dashboardTitle={item.dashboard.title} inviterNickname={item.inviter.nickname} />
+              </li>
+            ))}
           </ul>
         </div>
       </div>

--- a/src/pages/dashboards/DashboardList.tsx
+++ b/src/pages/dashboards/DashboardList.tsx
@@ -1,4 +1,5 @@
-import { Link } from 'react-router-dom';
+import { useState } from 'react';
+import { Link, useLoaderData } from 'react-router-dom';
 
 import AddIcon from '@/assets/icons/AddIcon';
 import ChevronIcon from '@/assets/icons/ChevronIcon';
@@ -6,9 +7,16 @@ import CrownIcon from '@/assets/icons/CrownIcon';
 import DotIcon from '@/assets/icons/DotIcon';
 import Button from '@/components/common/button';
 import Pagination from '@/components/pagination';
+import type { DashboardListLoaderData } from '@/loaders/dashboard/types';
+import type { Dashboard } from '@/schemas/dashboard';
+import type { Invitation } from '@/schemas/invitation';
 
 // my dashboard
 const DashboardList = () => {
+  const initialData = useLoaderData() as DashboardListLoaderData;
+  const [dashboardList, setDashboardList] = useState<Dashboard[]>(initialData.dashboardList.dashboards);
+  const [invitationList, setInvitationList] = useState<Invitation[]>(initialData.invitationList.invitations);
+
   return (
     <div className='flex w-full'>
       <div className='w-67 bg-white tablet:w-160 pc:w-300' />

--- a/src/schemas/invitation.ts
+++ b/src/schemas/invitation.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+
+/**
+ * To server
+ * @description 내가 받은 초대 목록 조회 요청 시 사용하는 쿼리 파라미터의 유효성을 검사하는 스키마
+ */
+export const invitationListParamsSchema = z.object({
+  size: z.number().int().positive().optional(),
+  cursorId: z.number().int().positive().optional(),
+  title: z.string().optional(),
+});
+
+/**
+ * To server
+ * @description 초대 응답 요청 시 사용하는 쿼리 파라미터의 유효성을 검사하는 스키마
+ */
+export const respondInvitationParamsSchema = z.object({
+  inviteAccepted: z.boolean(),
+});
+
+/**
+ * From server
+ * @description 초대 데이터의 유효성을 검사하는 스키마
+ */
+export const invitationSchema = z.object({
+  id: z.number(),
+  inviter: z.object({
+    nickname: z.string(),
+    email: z.string(),
+    id: z.number(),
+  }),
+  teamId: z.string(),
+  dashboard: z.object({
+    title: z.string(),
+    id: z.number(),
+  }),
+  invitee: z.object({
+    nickname: z.string(),
+    email: z.string(),
+    id: z.number(),
+  }),
+  inviteAccepted: z.boolean().nullable(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+/**
+ * From server
+ * @description 내가 받은 초대 목록 응답 데이터의 유효성을 검사하는 스키마
+ */
+export const invitationListSchema = z.object({
+  cursorId: z.number().nullable(),
+  invitations: z.array(invitationSchema),
+});
+
+export type InvitationListParams = z.infer<typeof invitationListParamsSchema>;
+export type RespondInvitationParams = z.infer<typeof respondInvitationParamsSchema>;
+export type Invitation = z.infer<typeof invitationSchema>;
+export type InvitationList = z.infer<typeof invitationListSchema>;


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- 이슈 번호 #140 
 
## ✨ 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->
내 대시보드 페이지의 내 대시보드 아이템, 초대받은 대시보드를 컴포넌트로 분리하였고, 실제 데이터를 불러와서 페이지에 적용시켰습니다.
미구현된 부분: 페이지네이션, 무한스크롤, 검색, 수락/거절
## 📌 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->

## ✅ 체크리스트

<!-- 체크리스트 내용을 수정하고 싶으면 회의 때 얘기부탁드려요. -->

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다.
  - [x] 구현 기간에 맞는 이슈에서 서브이슈로 등록했습니다.
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
  - [x] PR 사이드 탭에서는 Projects을 등록 하지않았습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->
![dataMobile](https://github.com/user-attachments/assets/f36236e1-5d2e-48d5-8533-77a903860124)
![dataTablet](https://github.com/user-attachments/assets/d8a59b08-39c9-46ab-b27e-a6c6ea4785f0)
![dataPc](https://github.com/user-attachments/assets/b14204a5-49a4-4148-a793-addb5fff876a)

## ❓무슨 문제가 발생했나요 ?

## 💬 논의 사항

<!-- 논의하고 싶은 사항을 적어 주시고, 토론이 필요하시면 토론 탭에 추가 부탁드립니다. -->

## 💬 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 대시보드 목록 페이지에 초대장 목록이 함께 표시됩니다.
  - 각 초대장은 초대한 사람과 대시보드 이름을 보여주며, "수락" 및 "거절" 버튼으로 응답할 수 있습니다.
  - 대시보드 항목과 초대장 항목 컴포넌트가 추가되어 목록이 동적으로 렌더링됩니다.
  - 초대장 관련 API가 추가되어 초대장 목록 조회 및 응답 기능이 지원됩니다.

- **리팩터**
  - 대시보드 및 초대장 목록 렌더링이 동적 데이터 기반으로 개선되었습니다.
  - 대시보드 및 초대장 데이터를 동시에 비동기 호출해 효율적으로 처리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->