### PR TITLE
✨Feat: 내 대시보드 페이지 - 페이지네이션,무한 스크롤

### DIFF
--- a/src/components/pagination/index.tsx
+++ b/src/components/pagination/index.tsx
@@ -13,6 +13,7 @@ import type PaginationProps from './types';
  * @param {number} currentPage - 현재 페이지 번호 (1부터 시작)
  * @param {number} totalPages - 전체 페이지 수
  * @param {(page: number) => void} onPageChange - 페이지가 변경될 때 호출되는 콜백 함수
+ * @param {boolean} isLoading - 로딩 여부
  *
  * @example
  * <Pagination
@@ -22,15 +23,15 @@ import type PaginationProps from './types';
  * />
  */
 
-const Pagination = ({ currentPage, totalPages, onPageChange }: PaginationProps) => {
+const Pagination = ({ currentPage, totalPages, onPageChange, isLoading }: PaginationProps) => {
   const paginationBtnStyle =
     'size-36 border border-gray-300 p-0 active:bg-gray-200 disabled:border-1 disabled:border-solid disabled:border-gray-800 disabled:bg-white disabled:opacity-20 tablet:size-40 bg-white';
   return (
-    <>
+    <div>
       <Button
         aria-label='이전 페이지'
         className={`${paginationBtnStyle} rounded-r-none`}
-        disabled={currentPage === 1}
+        disabled={currentPage === 1 || isLoading}
         variant='none'
         onClick={() => onPageChange(currentPage - 1)}
       >
@@ -39,13 +40,13 @@ const Pagination = ({ currentPage, totalPages, onPageChange }: PaginationProps) 
       <Button
         aria-label='다음 페이지'
         className={`${paginationBtnStyle} rounded-l-none`}
-        disabled={currentPage === totalPages}
+        disabled={currentPage === totalPages || isLoading}
         variant='none'
         onClick={() => onPageChange(currentPage + 1)}
       >
         <ChevronIcon direction='right' size={16} />
       </Button>
-    </>
+    </div>
   );
 };
 

--- a/src/components/pagination/types/index.ts
+++ b/src/components/pagination/types/index.ts
@@ -14,4 +14,10 @@ export default interface PaginationProps {
    * @param page - 이동할 페이지 번호
    */
   onPageChange: (page: number) => void;
+
+  /**
+   * 로딩 상태여부를 나타냅니다.
+   * `true`이면 로딩 중, `false`이면 로딩이 완료되었거나 시작되지 않은 상태입니다.
+   */
+  isLoading?: boolean;
 }

--- a/src/hooks/useInfiniteScroll/index.ts
+++ b/src/hooks/useInfiniteScroll/index.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+
+import type { UseInfiniteScrollProps } from './types';
+
+/**
+ * `useInfiniteScroll` 훅은 스크롤을 내리다가 뷰포트에 ref가 들어오면 콜백함수를 실행하는 무한 스크롤 기능을 제공합니다.
+ * 훅을 호출하면 ref를 반환하는데 이 ref를 콜백함수를 불러올 시점을 감지할 HTML div 요소에 연결하면 됩니다.
+ *
+ * @param {() => void} callback - 스크롤 트리거 요소가 뷰포트에 들어왔을 때 실행될 콜백 함수입니다.
+ * @param {boolean} isMoreData - 더 이상 불러올 데이터가 남아있는지 여부를 나타내는 값입니다.
+ * @returns {ref: RefObject<HTMLDivElement>} 무한 스크롤 감지를 위한 `ref` 객체를 반환합니다.
+ *
+ */
+export const useInfiniteScroll = ({ callback, isMoreData }: UseInfiniteScrollProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!ref.current || !isMoreData) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          callback();
+        }
+      },
+      { threshold: 0.1 }, //뷰 포트에 10% 이상 보일 때 콜백 실행
+    );
+
+    observer.observe(ref.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [isMoreData, callback]);
+  return ref;
+};

--- a/src/hooks/useInfiniteScroll/types/index.ts
+++ b/src/hooks/useInfiniteScroll/types/index.ts
@@ -1,0 +1,11 @@
+export interface UseInfiniteScrollProps {
+  /**
+   * 스크롤 트리거 요소가 뷰포트에 들어왔을 때 실행될 콜백 함수입니다.
+   */
+  callback: () => void;
+  /**
+   * 더 이상 불러올 데이터가 남아있는지 여부를 나타내는 불리언 값입니다.
+   * `false`일 경우 무한 스크롤 기능이 비활성화되어 불필요한 콜백 호출을 방지합니다.
+   */
+  isMoreData: boolean;
+}

--- a/src/pages/dashboards/DashboardList.tsx
+++ b/src/pages/dashboards/DashboardList.tsx
@@ -58,7 +58,7 @@ const DashboardList = () => {
           </ul>
 
           {totalDashboardPage > 1 && (
-            <div className='mt-16 mb-24 flex items-center justify-end tablet:mb-48'>
+            <div className='mt-16 mb-24 flex items-center justify-end tablet:mb-48 pc:-mb-34'>
               <span className='mr-16 text-xs font-normal tablet:text-md'>
                 {page} 페이지 중 {totalDashboardPage}
               </span>
@@ -66,7 +66,7 @@ const DashboardList = () => {
             </div>
           )}
         </div>
-        <div className='flex flex-col rounded-lg bg-white'>
+        <div className='mt-32 flex flex-col rounded-lg bg-white tablet:mt-40 pc:mt-74'>
           <div className='flex flex-col gap-16 px-16 py-24 tablet:px-28 tablet:py-32'>
             <h2 className='text-xl font-bold tablet:text-2xl'>초대받은 대시보드</h2>
             <input className='h-36 border border-gray-300' placeholder='검색' />

--- a/src/pages/dashboards/DashboardList.tsx
+++ b/src/pages/dashboards/DashboardList.tsx
@@ -43,14 +43,14 @@ const DashboardList = () => {
       }
     };
     fetchDashboard();
-  }, [page, isDashboardLoading]);
+  }, [page]);
 
   const fetchMoreInvitation = useCallback(async () => {
     if (!cursorId || isInvitationLoading) return;
     setIsInvitationLoading(true);
     try {
       const rawMoreInvitation = await getInvitationList({ cursorId });
-      const invitationList = await invitationListSchema.parse(rawMoreInvitation);
+      const invitationList = invitationListSchema.parse(rawMoreInvitation);
       setInvitationList((prev) => [...prev, ...invitationList.invitations]);
       setCursorId(invitationList.cursorId);
     } catch (error) {

--- a/src/pages/dashboards/DashboardList.tsx
+++ b/src/pages/dashboards/DashboardList.tsx
@@ -4,6 +4,7 @@ import { useLoaderData } from 'react-router-dom';
 import { getDashboardList } from '@/apis/dashboard';
 import { getInvitationList } from '@/apis/invitation';
 import AddIcon from '@/assets/icons/AddIcon';
+import NoInvitation from '@/assets/icons/NoInvitationIcon';
 import Button from '@/components/common/button';
 import DashboardItem from '@/components/dashboardItem';
 import InvitationItem from '@/components/invitationItem';
@@ -89,14 +90,23 @@ const DashboardList = () => {
         <div className='mt-32 flex flex-col rounded-lg bg-white tablet:mt-40 pc:mt-74'>
           <div className='flex flex-col gap-16 px-16 py-24 tablet:px-28 tablet:py-32'>
             <h2 className='text-xl font-bold tablet:text-2xl'>초대받은 대시보드</h2>
-            <input className='h-36 border border-gray-300' placeholder='검색' />
+            {invitationList.length > 0 ? (
+              <input className='h-36 border border-gray-300' placeholder='검색' />
+            ) : (
+              <div className='flex flex-col items-center justify-center gap-16 pt-105 pb-80 tablet:gap-24 tablet:pt-64 tablet:pb-120'>
+                <NoInvitation className='size-53 tablet:size-88' />
+                <p className='text-md font-normal text-gray-400 tablet:text-2lg'>아직 초대받은 대시보드가 없어요</p>
+              </div>
+            )}
           </div>
           <ul>
-            <li className='hidden px-28 text-gray-400 tablet:flex pc:px-76'>
-              <span className='w-3/10'>이름</span>
-              <span className='w-2/10'>초대자</span>
-              <span className='w-4/10 text-center'>수락 여부</span>
-            </li>
+            {invitationList.length > 0 && (
+              <li className='hidden px-28 text-gray-400 tablet:flex pc:px-76'>
+                <span className='w-3/10'>이름</span>
+                <span className='w-2/10'>초대자</span>
+                <span className='w-4/10 text-center'>수락 여부</span>
+              </li>
+            )}
             {invitationList.map((item) => (
               <li
                 key={item.id}

--- a/src/pages/dashboards/DashboardList.tsx
+++ b/src/pages/dashboards/DashboardList.tsx
@@ -1,20 +1,39 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLoaderData } from 'react-router-dom';
 
+import { getDashboardList } from '@/apis/dashboard';
 import AddIcon from '@/assets/icons/AddIcon';
 import Button from '@/components/common/button';
 import DashboardItem from '@/components/dashboardItem';
 import InvitationItem from '@/components/invitationItem';
 import Pagination from '@/components/pagination';
 import type { DashboardListLoaderData } from '@/loaders/dashboard/types';
-import type { Dashboard } from '@/schemas/dashboard';
+import { type Dashboard, dashboardListResponseSchema } from '@/schemas/dashboard';
 import type { Invitation } from '@/schemas/invitation';
 
 // my dashboard
 const DashboardList = () => {
   const initialData = useLoaderData() as DashboardListLoaderData;
+
   const [dashboardList, setDashboardList] = useState<Dashboard[]>(initialData.dashboardList.dashboards);
+  const [page, setPage] = useState<number>(1);
+  const totalDashboardCount = initialData.dashboardList.totalCount;
+  const totalDashboardPage = Math.ceil(totalDashboardCount / 5);
+
   const [invitationList, setInvitationList] = useState<Invitation[]>(initialData.invitationList.invitations);
+
+  useEffect(() => {
+    const fetchDashboard = async () => {
+      try {
+        const rawDashboardList = await getDashboardList({ navigationMethod: 'pagination', size: 5, page });
+        const dashboardList = dashboardListResponseSchema.parse(rawDashboardList);
+        setDashboardList(dashboardList.dashboards);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    fetchDashboard();
+  }, [page]);
 
   return (
     <div className='flex w-full'>
@@ -38,10 +57,14 @@ const DashboardList = () => {
             ))}
           </ul>
 
-          <div className='mt-16 mb-24 flex items-center justify-end tablet:mb-48'>
-            <span className='mr-16 text-xs font-normal tablet:text-md'>1 페이지 중 1</span>
-            <Pagination currentPage={1} totalPages={4} onPageChange={() => {}} />
-          </div>
+          {totalDashboardPage > 1 && (
+            <div className='mt-16 mb-24 flex items-center justify-end tablet:mb-48'>
+              <span className='mr-16 text-xs font-normal tablet:text-md'>
+                {page} 페이지 중 {totalDashboardPage}
+              </span>
+              <Pagination currentPage={page} totalPages={totalDashboardPage} onPageChange={setPage} />
+            </div>
+          )}
         </div>
         <div className='flex flex-col rounded-lg bg-white'>
           <div className='flex flex-col gap-16 px-16 py-24 tablet:px-28 tablet:py-32'>

--- a/src/pages/dashboards/DashboardList.tsx
+++ b/src/pages/dashboards/DashboardList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLoaderData } from 'react-router-dom';
 
 import { getDashboardList } from '@/apis/dashboard';
@@ -28,7 +28,14 @@ const DashboardList = () => {
   const [isInvitationLoading, setIsInvitationLoading] = useState<boolean>(false);
   const [cursorId, setCursorId] = useState<number | null>(initialData.invitationList.cursorId);
 
+  const isInitialRender = useRef(true);
+
   useEffect(() => {
+    if (isInitialRender.current) {
+      isInitialRender.current = false;
+      return;
+    }
+
     const fetchDashboard = async () => {
       if (isDashboardLoading) return;
       setIsDashboardLoading(true);

--- a/src/schemas/dashboard.ts
+++ b/src/schemas/dashboard.ts
@@ -42,6 +42,7 @@ export const dashboardListParamsSchema = z.object({
 export const dashboardListResponseSchema = z.object({
   dashboards: z.array(dashboardSchema),
   cursorId: z.number().nullable(),
+  totalCount: z.number(),
 });
 
 //! 유효성 에러 메시지 처리는 react-hook-form에서 처리할수도 있고 추후 다시 정리


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- 이슈 번호 #194 

## ✨ 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->
내 대시보드 페이지의 내 대시보드 페이지네이션, 초대받은 목록 무한 스크롤 기능을 구현했습니다.
무한스크롤 hook을 추가했습니다. 
초대목록이 없을 때 ui를 추가했습니다.
페이지네이션 컴포넌트에 로딩 상태를 추가했습니다.
내 대시보드 페이지의 로딩상태를 추가했습니다

## 📌 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->

## ✅ 체크리스트

<!-- 체크리스트 내용을 수정하고 싶으면 회의 때 얘기부탁드려요. -->

- [ ] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다.
  - [ ] 구현 기간에 맞는 이슈에서 서브이슈로 등록했습니다.
  - [ ] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
  - [ ] PR 사이드 탭에서는 Projects을 등록 하지않았습니다.
- [ ] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [ ] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [ ] 변경사항을 충분히 테스트 했습니다.
- [ ] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [ ] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->


https://github.com/user-attachments/assets/1fa49256-b1e6-45fc-a4af-2ff331842815
![emptyPc](https://github.com/user-attachments/assets/64c1e634-d101-41c3-bfaa-bc7ab75c58d5)
![emptyTablet](https://github.com/user-attachments/assets/48c78693-7d64-443c-ac96-41ccdabb6b41)
![emptyMobile](https://github.com/user-attachments/assets/fa9c07d0-0d4f-40e8-9943-7afc2f0b515e)



## ❓무슨 문제가 발생했나요 ?

## 💬 논의 사항

<!-- 논의하고 싶은 사항을 적어 주시고, 토론이 필요하시면 토론 탭에 추가 부탁드립니다. -->

## 💬 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->
페이지가 처음 렌더링 될 때 불러오는 데이터가 이미 로더에서 불러오는 데이터와 동일해서 처음 렌더링 시에 useEffect에서 데이터를 불러오지 않게 했습니다. 하지만 Strict 모드 때문에 useEffect가 두번 동작하여 동일한 데이터를 한번 불러오게 됩니다. strictmode를 제거하니 첫 데이터를 불러오지 않는것을 확인했습니다.

