### PR TITLE
✨Feat: 대시보드 수정페이지 페이지네이션

### DIFF
--- a/src/apis/dashboard.ts
+++ b/src/apis/dashboard.ts
@@ -56,5 +56,6 @@ export const deleteDashboard = async (dashboardId: number) => {
  * @param params 쿼리 파라미터 (dashboardId, page, size)
  */
 export const getInviteeList = async (params: InviteeListParams) => {
-  return requestGet<InviteeList>(DASHBOARD_ENDPOINTS.GET_INVITATIONS(String(params.dashboardId)), { params });
+  const { dashboardId, ...queryParams } = params;
+  return requestGet<InviteeList>(DASHBOARD_ENDPOINTS.GET_INVITATIONS(String(dashboardId)), { params: queryParams });
 };

--- a/src/apis/dashboard.ts
+++ b/src/apis/dashboard.ts
@@ -5,8 +5,8 @@ import type {
   Dashboard,
   DashboardListData,
   DashboardListParams,
-  InvitationList,
-  InvitationListParams,
+  InviteeList,
+  InviteeListParams,
   UpdateDashboardInput,
 } from '@/schemas/dashboard';
 
@@ -55,6 +55,6 @@ export const deleteDashboard = async (dashboardId: number) => {
  * @description 특정 대시보드 초대 목록을 조회합니다.
  * @param params 쿼리 파라미터 (dashboardId, page, size)
  */
-export const getInvitationList = async (params: InvitationListParams) => {
-  return requestGet<InvitationList>(DASHBOARD_ENDPOINTS.GET_INVITATIONS(String(params.dashboardId)), { params });
+export const getInviteeList = async (params: InviteeListParams) => {
+  return requestGet<InviteeList>(DASHBOARD_ENDPOINTS.GET_INVITATIONS(String(params.dashboardId)), { params });
 };

--- a/src/apis/dashboard.ts
+++ b/src/apis/dashboard.ts
@@ -5,6 +5,8 @@ import type {
   Dashboard,
   DashboardListData,
   DashboardListParams,
+  InvitationList,
+  InvitationListParams,
   UpdateDashboardInput,
 } from '@/schemas/dashboard';
 
@@ -47,4 +49,12 @@ export const updateDashboard = async (dashboardId: number, dashboardInput: Updat
  */
 export const deleteDashboard = async (dashboardId: number) => {
   return requestDelete(`${DASHBOARD_ENDPOINTS.DELETE}/${dashboardId}`);
+};
+
+/**
+ * @description 특정 대시보드 초대 목록을 조회합니다.
+ * @param params 쿼리 파라미터 (dashboardId, page, size)
+ */
+export const getInvitationList = async (params: InvitationListParams) => {
+  return requestGet<InvitationList>(DASHBOARD_ENDPOINTS.GET_INVITATIONS(String(params.dashboardId)), { params });
 };

--- a/src/components/dashboardEdit/invitations.tsx
+++ b/src/components/dashboardEdit/invitations.tsx
@@ -1,12 +1,12 @@
-import Button from '../common/button';
-import type { InvitationsProps } from './types';
+import Button from '@/components/common/button';
+import type { InvitationsProps } from '@/components/dashboardEdit/types';
 
 const Invitations = ({ email, isLast }: InvitationsProps) => {
   return (
     <>
       <li className='flex items-center justify-between px-20 py-12 tablet:px-28 tablet:py-16'>
         <div className='text-md tablet:text-lg'>{email}</div>
-        <Button className='w-52 p-0 tablet:w-84 tablet:text-md' size='sm' type='button' variant='outlined'>
+        <Button className='w-52 tablet:w-84 tablet:text-md' size='sm' type='button' variant='outlined'>
           취소
         </Button>
       </li>

--- a/src/components/dashboardEdit/invitations.tsx
+++ b/src/components/dashboardEdit/invitations.tsx
@@ -1,0 +1,18 @@
+import Button from '../common/button';
+import type { InvitationsProps } from './types';
+
+const Invitations = ({ email, isLast }: InvitationsProps) => {
+  return (
+    <>
+      <li className='flex items-center justify-between px-20 py-12 tablet:px-28 tablet:py-16'>
+        <div className='text-md tablet:text-lg'>{email}</div>
+        <Button className='w-52 p-0 tablet:w-84 tablet:text-md' size='sm' type='button' variant='outlined'>
+          취소
+        </Button>
+      </li>
+      {!isLast && <div className='border-b border-gray-200' />}
+    </>
+  );
+};
+
+export default Invitations;

--- a/src/components/dashboardEdit/members.tsx
+++ b/src/components/dashboardEdit/members.tsx
@@ -1,0 +1,22 @@
+import Avatar from '../Avatar';
+import Button from '../common/button';
+import type { MembersProps } from './types';
+
+const Members = ({ nickname, profileImg, isLast }: MembersProps) => {
+  return (
+    <>
+      <li className='flex items-center justify-between px-20 py-12 tablet:px-28 tablet:py-16'>
+        <div className='flex items-center justify-between gap-8'>
+          <Avatar nickname={nickname} src={profileImg} />
+          <span className='text-md tablet:text-lg'>{nickname}</span>
+        </div>
+        <Button className='w-52 p-0 tablet:w-84 tablet:text-md' size='sm' type='button' variant='outlined'>
+          삭제
+        </Button>
+      </li>
+      {!isLast && <div className='border-b border-gray-200' />}
+    </>
+  );
+};
+
+export default Members;

--- a/src/components/dashboardEdit/members.tsx
+++ b/src/components/dashboardEdit/members.tsx
@@ -1,8 +1,9 @@
-import Avatar from '../Avatar';
-import Button from '../common/button';
-import type { MembersProps } from './types';
+import CrownIcon from '@/assets/icons/CrownIcon';
+import Avatar from '@/components/Avatar';
+import Button from '@/components/common/button';
+import type { MembersProps } from '@/components/dashboardEdit/types';
 
-const Members = ({ nickname, profileImg, isLast }: MembersProps) => {
+const Members = ({ nickname, profileImg, isLast, isOwner }: MembersProps) => {
   return (
     <>
       <li className='flex items-center justify-between px-20 py-12 tablet:px-28 tablet:py-16'>
@@ -10,9 +11,16 @@ const Members = ({ nickname, profileImg, isLast }: MembersProps) => {
           <Avatar nickname={nickname} src={profileImg} />
           <span className='text-md tablet:text-lg'>{nickname}</span>
         </div>
-        <Button className='w-52 p-0 tablet:w-84 tablet:text-md' size='sm' type='button' variant='outlined'>
-          삭제
-        </Button>
+        {isOwner ? (
+          <span className='flex w-84 items-center justify-center gap-4'>
+            <CrownIcon size={20} />
+            <span>Owner</span>
+          </span>
+        ) : (
+          <Button className='w-52 p-0 tablet:w-84 tablet:text-md' size='sm' type='button' variant='outlined'>
+            삭제
+          </Button>
+        )}
       </li>
       {!isLast && <div className='border-b border-gray-200' />}
     </>

--- a/src/components/dashboardEdit/types/index.ts
+++ b/src/components/dashboardEdit/types/index.ts
@@ -6,6 +6,10 @@ export interface MembersProps {
    */
   nickname: string;
   /**
+   * 대시보드 오너 여부
+   */
+  isOwner: boolean;
+  /**
    * 프로필 이미지 URL
    * (이미지가 없을 경우 기본 아바타로 대체될 수 있습니다.)
    */

--- a/src/components/dashboardEdit/types/index.ts
+++ b/src/components/dashboardEdit/types/index.ts
@@ -1,0 +1,30 @@
+type ProfileImg = string | undefined;
+
+export interface MembersProps {
+  /**
+   * 사용자 닉네임
+   */
+  nickname: string;
+  /**
+   * 프로필 이미지 URL
+   * (이미지가 없을 경우 기본 아바타로 대체될 수 있습니다.)
+   */
+  profileImg: ProfileImg;
+  /**
+   * 리스트의 마지막 항목 여부
+   * (렌더링 시 구분선 생략 등 UI 처리를 위한 플래그)
+   */
+  isLast: boolean;
+}
+
+export interface InvitationsProps {
+  /**
+   * 초대받은 이메일 주소
+   */
+  email: string;
+  /**
+   * 리스트의 마지막 항목 여부
+   * (렌더링 시 구분선 생략 등 UI 처리를 위한 플래그)
+   */
+  isLast: boolean;
+}

--- a/src/components/pagination/index.tsx
+++ b/src/components/pagination/index.tsx
@@ -13,6 +13,7 @@ import type PaginationProps from './types';
  * @param {number} currentPage - 현재 페이지 번호 (1부터 시작)
  * @param {number} totalPages - 전체 페이지 수
  * @param {(page: number) => void} onPageChange - 페이지가 변경될 때 호출되는 콜백 함수
+ * @param {boolean} isLoading - 로딩 여부
  *
  * @example
  * <Pagination
@@ -22,15 +23,16 @@ import type PaginationProps from './types';
  * />
  */
 
-const Pagination = ({ currentPage, totalPages, onPageChange }: PaginationProps) => {
+const Pagination = ({ currentPage, totalPages, onPageChange, isLoading }: PaginationProps) => {
   const paginationBtnStyle =
-    'size-36 border border-gray-300 p-0 active:bg-gray-200 disabled:border-1 disabled:border-solid disabled:border-gray-800 disabled:bg-white disabled:opacity-20 tablet:size-40 bg-white';
+    'size-36 border border-gray-300 active:bg-gray-200 disabled:border-1 disabled:border-solid disabled:border-gray-800 disabled:bg-white disabled:opacity-20 tablet:size-40 bg-white';
   return (
     <div>
       <Button
         aria-label='이전 페이지'
         className={`${paginationBtnStyle} rounded-r-none`}
-        disabled={currentPage === 1}
+        disabled={currentPage === 1 || isLoading}
+        size='none'
         variant='none'
         onClick={() => onPageChange(currentPage - 1)}
       >
@@ -39,7 +41,8 @@ const Pagination = ({ currentPage, totalPages, onPageChange }: PaginationProps) 
       <Button
         aria-label='다음 페이지'
         className={`${paginationBtnStyle} rounded-l-none`}
-        disabled={currentPage === totalPages}
+        disabled={currentPage === totalPages || isLoading}
+        size='none'
         variant='none'
         onClick={() => onPageChange(currentPage + 1)}
       >

--- a/src/components/pagination/index.tsx
+++ b/src/components/pagination/index.tsx
@@ -26,7 +26,7 @@ const Pagination = ({ currentPage, totalPages, onPageChange }: PaginationProps) 
   const paginationBtnStyle =
     'size-36 border border-gray-300 p-0 active:bg-gray-200 disabled:border-1 disabled:border-solid disabled:border-gray-800 disabled:bg-white disabled:opacity-20 tablet:size-40 bg-white';
   return (
-    <>
+    <div>
       <Button
         aria-label='이전 페이지'
         className={`${paginationBtnStyle} rounded-r-none`}
@@ -45,7 +45,7 @@ const Pagination = ({ currentPage, totalPages, onPageChange }: PaginationProps) 
       >
         <ChevronIcon direction='right' size={16} />
       </Button>
-    </>
+    </div>
   );
 };
 

--- a/src/components/pagination/types/index.ts
+++ b/src/components/pagination/types/index.ts
@@ -14,4 +14,10 @@ export default interface PaginationProps {
    * @param page - 이동할 페이지 번호
    */
   onPageChange: (page: number) => void;
+
+  /**
+   * 로딩 상태여부를 나타냅니다.
+   * `true`이면 로딩 중, `false`이면 로딩이 완료되었거나 시작되지 않은 상태입니다.
+   */
+  isLoading?: boolean;
 }

--- a/src/loaders/dashboard/editLoader.ts
+++ b/src/loaders/dashboard/editLoader.ts
@@ -1,13 +1,12 @@
 import { HttpStatusCode } from 'axios';
 import type { LoaderFunctionArgs } from 'react-router';
 
-import { getInvitationList } from '@/apis/dashboard';
+import { getInviteeList } from '@/apis/dashboard';
 import { getMemberList } from '@/apis/member';
-import { invitationListSchema } from '@/schemas/dashboard';
+import type { DashboardEditLoaderData } from '@/loaders/dashboard/types';
+import { inviteeListSchema } from '@/schemas/dashboard';
 import { memberListResponseSchema } from '@/schemas/member';
 import handleLoaderError from '@/utils/error/handleLoaderError';
-
-import type { DashboardEditLoaderData } from './types';
 
 export const loader = async ({ params }: LoaderFunctionArgs): Promise<DashboardEditLoaderData> => {
   const dashboardIdString: string | undefined = params.dashboardId;
@@ -33,7 +32,7 @@ export const loader = async ({ params }: LoaderFunctionArgs): Promise<DashboardE
   try {
     const results = await Promise.allSettled([
       getMemberList({ dashboardId, size: 4 }),
-      getInvitationList({ dashboardId, size: 5 }),
+      getInviteeList({ dashboardId, size: 5 }),
     ]);
 
     const rejectedPromises = results.filter((result) => result.status === 'rejected');
@@ -47,12 +46,12 @@ export const loader = async ({ params }: LoaderFunctionArgs): Promise<DashboardE
       throw rejectedPromises[0].reason;
     }
     const rawMemberList = (results[0] as PromiseFulfilledResult<unknown>).value;
-    const rawInvitationList = (results[1] as PromiseFulfilledResult<unknown>).value;
+    const rawInviteeList = (results[1] as PromiseFulfilledResult<unknown>).value;
 
     const memberList = memberListResponseSchema.parse(rawMemberList);
-    const invitationList = invitationListSchema.parse(rawInvitationList);
+    const inviteeList = inviteeListSchema.parse(rawInviteeList);
 
-    return { memberList, invitationList };
+    return { memberList, inviteeList };
   } catch (error) {
     return handleLoaderError(error);
   }

--- a/src/loaders/dashboard/editLoader.ts
+++ b/src/loaders/dashboard/editLoader.ts
@@ -39,7 +39,7 @@ export const loader = async ({ params }: LoaderFunctionArgs): Promise<DashboardE
 
     if (rejectedPromises.length > 0) {
       rejectedPromises.forEach((promise, index) => {
-        const apiName = index === 0 ? 'getMemberList' : 'getInvitationList';
+        const apiName = index === 0 ? 'getMemberList' : 'getInviteeList';
         console.error(`🩺 ${apiName} API 호출 실패:`, (promise as PromiseRejectedResult).reason);
       });
       // 첫 번째 에러를 ErrorBoundary로 던져서 UI를 중단시킵니다.

--- a/src/loaders/dashboard/editLoader.ts
+++ b/src/loaders/dashboard/editLoader.ts
@@ -1,3 +1,59 @@
-export const loader = async () => {
-  return null;
+import { HttpStatusCode } from 'axios';
+import type { LoaderFunctionArgs } from 'react-router';
+
+import { getInvitationList } from '@/apis/dashboard';
+import { getMemberList } from '@/apis/member';
+import { invitationListSchema } from '@/schemas/dashboard';
+import { memberListResponseSchema } from '@/schemas/member';
+import handleLoaderError from '@/utils/error/handleLoaderError';
+
+import type { DashboardEditLoaderData } from './types';
+
+export const loader = async ({ params }: LoaderFunctionArgs): Promise<DashboardEditLoaderData> => {
+  const dashboardIdString: string | undefined = params.dashboardId;
+
+  if (!dashboardIdString) {
+    throw new Response(JSON.stringify({ message: 'URL 파라미터에 dashboardId가 누락되었습니다.' }), {
+      status: HttpStatusCode.BadRequest,
+    });
+  }
+
+  const dashboardId: number = Number(dashboardIdString);
+  if (isNaN(dashboardId)) {
+    console.error(`🩺 Invalid Dashboard ID: "${dashboardIdString}" is not a number.`);
+    throw new Response(
+      JSON.stringify({
+        message: `URL 파라미터 dashboardId가 유효한 숫자가 아닙니다: "${dashboardIdString}"`,
+      }),
+      {
+        status: HttpStatusCode.BadRequest,
+      },
+    );
+  }
+  try {
+    const results = await Promise.allSettled([
+      getMemberList({ dashboardId, size: 4 }),
+      getInvitationList({ dashboardId, size: 5 }),
+    ]);
+
+    const rejectedPromises = results.filter((result) => result.status === 'rejected');
+
+    if (rejectedPromises.length > 0) {
+      rejectedPromises.forEach((promise, index) => {
+        const apiName = index === 0 ? 'getMemberList' : 'getInvitationList';
+        console.error(`🩺 ${apiName} API 호출 실패:`, (promise as PromiseRejectedResult).reason);
+      });
+      // 첫 번째 에러를 ErrorBoundary로 던져서 UI를 중단시킵니다.
+      throw rejectedPromises[0].reason;
+    }
+    const rawMemberList = (results[0] as PromiseFulfilledResult<unknown>).value;
+    const rawInvitationList = (results[1] as PromiseFulfilledResult<unknown>).value;
+
+    const memberList = memberListResponseSchema.parse(rawMemberList);
+    const invitationList = invitationListSchema.parse(rawInvitationList);
+
+    return { memberList, invitationList };
+  } catch (error) {
+    return handleLoaderError(error);
+  }
 };

--- a/src/loaders/dashboard/types/index.ts
+++ b/src/loaders/dashboard/types/index.ts
@@ -1,5 +1,4 @@
-import type { Dashboard, DashboardListData } from '@/schemas/dashboard';
-import type { InvitationList } from '@/schemas/invitation';
+import type { Dashboard, DashboardListData, InvitationList } from '@/schemas/dashboard';
 import type { MemberListData } from '@/schemas/member';
 
 /**
@@ -19,5 +18,14 @@ export interface DashboardDetailLoaderData {
  */
 export interface DashboardListLoaderData {
   dashboardList: DashboardListData;
+  invitationList: InvitationList;
+}
+/**
+ * @description 대시보드 수정 페이지 로더(editLoader)가 반환하는 데이터의 타입입니다.
+ * @property {import('@/schemas/dashboard').DashboardListData} memberList - 구성원 리스트 응답 데이터입니다.
+ * @property {import('@/schemas/invitation').InvitationList} invitationList - 대시보드 초대 받은 리스트 응답 데이터입니다.
+ */
+export interface DashboardEditLoaderData {
+  memberList: MemberListData;
   invitationList: InvitationList;
 }

--- a/src/loaders/dashboard/types/index.ts
+++ b/src/loaders/dashboard/types/index.ts
@@ -23,7 +23,7 @@ export interface DashboardListLoaderData {
 }
 /**
  * @description 대시보드 수정 페이지 로더(editLoader)가 반환하는 데이터의 타입입니다.
- * @property {import('@/schemas/dashboard').DashboardListData} memberList - 구성원 리스트 응답 데이터입니다.
+ * @property {import('@/schemas/member').MemberListData} memberList - 구성원 리스트 응답 데이터입니다.
  * @property {import('@/schemas/dashboard').InviteeList} inviteeList - 대시보드 초대 받은 리스트 응답 데이터입니다.
  */
 export interface DashboardEditLoaderData {

--- a/src/loaders/dashboard/types/index.ts
+++ b/src/loaders/dashboard/types/index.ts
@@ -1,4 +1,5 @@
-import type { Dashboard, DashboardListData, InvitationList } from '@/schemas/dashboard';
+import type { Dashboard, DashboardListData, InviteeList } from '@/schemas/dashboard';
+import type { InvitationList } from '@/schemas/invitation';
 import type { MemberListData } from '@/schemas/member';
 
 /**
@@ -23,9 +24,9 @@ export interface DashboardListLoaderData {
 /**
  * @description 대시보드 수정 페이지 로더(editLoader)가 반환하는 데이터의 타입입니다.
  * @property {import('@/schemas/dashboard').DashboardListData} memberList - 구성원 리스트 응답 데이터입니다.
- * @property {import('@/schemas/invitation').InvitationList} invitationList - 대시보드 초대 받은 리스트 응답 데이터입니다.
+ * @property {import('@/schemas/dashboard').InviteeList} inviteeList - 대시보드 초대 받은 리스트 응답 데이터입니다.
  */
 export interface DashboardEditLoaderData {
   memberList: MemberListData;
-  invitationList: InvitationList;
+  inviteeList: InviteeList;
 }

--- a/src/pages/dashboards/DashboardEdit.tsx
+++ b/src/pages/dashboards/DashboardEdit.tsx
@@ -94,7 +94,7 @@ const DashboardEdit = () => {
       </div>
       <div className='flex flex-col gap-24'>
         <div className='flex flex-col gap-16'>
-          <section className='flex h-312 max-w-620 flex-col gap-32 rounded-lg bg-white px-16 py-20 tablet:h-344 tablet:gap-40 tablet:px-28 tablet:py-32'>
+          <section className='flex max-w-620 flex-col gap-32 rounded-lg bg-white px-16 py-20 tablet:gap-40 tablet:px-28 tablet:py-32'>
             <div className='flex flex-col gap-24'>
               <h2 className='text-xl font-bold tablet:text-2xl'>비브리지</h2>
               <div className='flex flex-col gap-16'>
@@ -114,7 +114,7 @@ const DashboardEdit = () => {
               변경
             </Button>
           </section>
-          <section className='flex h-337 max-w-620 flex-col rounded-lg bg-white tablet:h-404'>
+          <section className='flex max-w-620 flex-col rounded-lg bg-white'>
             <div className='flex items-center justify-between p-20 tablet:p-28'>
               <h2 className='flex-grow text-xl font-bold tablet:text-2xl'>구성원</h2>
               <span className='pr-12 text-xs tablet:pr-16 tablet:text-md'>
@@ -144,7 +144,7 @@ const DashboardEdit = () => {
               })}
             </ul>
           </section>
-          <section className='h-406 max-w-620 rounded-lg bg-white tablet:h-477'>
+          <section className='max-w-620 rounded-lg bg-white'>
             <div className='flex items-center justify-between p-20 tablet:p-28'>
               <h2 className='flex-grow text-xl font-bold tablet:text-2xl'>초대내역</h2>
               <span className='pr-12 text-xs tablet:pr-16 tablet:text-md'>

--- a/src/pages/dashboards/DashboardEdit.tsx
+++ b/src/pages/dashboards/DashboardEdit.tsx
@@ -130,10 +130,16 @@ const DashboardEdit = () => {
             <div className='px-20 text-md text-gray-400 tablet:px-28 tablet:text-lg'>이름</div>
             <ul>
               {memberList.map((member, index, arr) => {
-                const { userId, nickname, profileImageUrl } = member;
+                const { userId, nickname, profileImageUrl, isOwner } = member;
                 const isLast = index === arr.length - 1;
                 return (
-                  <Members key={userId} isLast={isLast} nickname={nickname} profileImg={profileImageUrl ?? undefined} />
+                  <Members
+                    key={userId}
+                    isLast={isLast}
+                    isOwner={isOwner}
+                    nickname={nickname}
+                    profileImg={profileImageUrl ?? undefined}
+                  />
                 );
               })}
             </ul>

--- a/src/pages/dashboards/DashboardEdit.tsx
+++ b/src/pages/dashboards/DashboardEdit.tsx
@@ -84,9 +84,6 @@ const DashboardEdit = () => {
     fetchInvitation();
   }, [invitationPage]);
 
-  console.log(memberList);
-  console.log(invitationList);
-
   return (
     <div className='flex min-h-screen flex-col gap-6 bg-gray-100 px-12 py-16'>
       <div className='flex items-center gap-8'>

--- a/src/pages/dashboards/DashboardEdit.tsx
+++ b/src/pages/dashboards/DashboardEdit.tsx
@@ -24,7 +24,7 @@ const DashboardEdit = () => {
   const [memberPage, setMemberPage] = useState<number>(1);
   const [isMemberLoading, setIsMemberLoading] = useState<boolean>(false);
   const totalMemberCount = initialData.memberList.totalCount;
-  const totalMemberPage = Math.ceil(totalMemberCount / 5);
+  const totalMemberPage = Math.ceil(totalMemberCount / 4);
 
   const [inviteeList, setInviteeList] = useState<Invitation[]>(initialData.inviteeList.invitations);
   const [inviteePage, setInviteePage] = useState<number>(1);

--- a/src/pages/dashboards/DashboardEdit.tsx
+++ b/src/pages/dashboards/DashboardEdit.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useLoaderData, useParams } from 'react-router';
 
-import { getInvitationList } from '@/apis/dashboard';
+import { getInviteeList } from '@/apis/dashboard';
 import { getMemberList } from '@/apis/member';
 import AddBoxIcon from '@/assets/icons/AddBoxIcon';
 import ChevronIcon from '@/assets/icons/ChevronIcon';
@@ -11,7 +11,7 @@ import Invitations from '@/components/dashboardEdit/invitations';
 import Members from '@/components/dashboardEdit/members';
 import Pagination from '@/components/pagination';
 import type { DashboardEditLoaderData } from '@/loaders/dashboard/types';
-import { invitationListSchema } from '@/schemas/dashboard';
+import { inviteeListSchema } from '@/schemas/dashboard';
 import type { Invitation } from '@/schemas/invitation';
 import type { Member } from '@/schemas/member';
 import { memberListResponseSchema } from '@/schemas/member';
@@ -26,11 +26,11 @@ const DashboardEdit = () => {
   const totalMemberCount = initialData.memberList.totalCount;
   const totalMemberPage = Math.ceil(totalMemberCount / 5);
 
-  const [invitationList, setInvitationList] = useState<Invitation[]>(initialData.invitationList.invitations);
-  const [invitationPage, setInvitationPage] = useState<number>(1);
-  const [isInvitationLoading, setIsInvitationLoading] = useState<boolean>(false);
-  const totalInvitationCount = initialData.invitationList.totalCount;
-  const totalInvitationPage = Math.ceil(totalInvitationCount / 5);
+  const [inviteeList, setInviteeList] = useState<Invitation[]>(initialData.inviteeList.invitations);
+  const [inviteePage, setInviteePage] = useState<number>(1);
+  const [isInviteeLoading, setIsInviteeLoading] = useState<boolean>(false);
+  const totalInviteeCount = initialData.inviteeList.totalCount;
+  const totalInviteePage = Math.ceil(totalInviteeCount / 5);
 
   const isMemberRender = useRef(true);
 
@@ -56,33 +56,33 @@ const DashboardEdit = () => {
     fetchMember();
   }, [memberPage]);
 
-  const isInvitationRender = useRef(true);
+  const isInviteeRender = useRef(true);
 
   useEffect(() => {
-    if (isInvitationRender.current) {
-      isInvitationRender.current = false;
+    if (isInviteeRender.current) {
+      isInviteeRender.current = false;
       return;
     }
 
     const fetchInvitation = async () => {
-      if (isInvitationLoading) return;
-      setIsInvitationLoading(true);
+      if (isInviteeLoading) return;
+      setIsInviteeLoading(true);
       try {
-        const rawInvitationList = await getInvitationList({
+        const rawInviteeList = await getInviteeList({
           dashboardId: dashboardIdNumber,
           size: 5,
-          page: invitationPage,
+          page: inviteePage,
         });
-        const invitationList = invitationListSchema.parse(rawInvitationList);
-        setInvitationList(invitationList.invitations);
+        const inviteeList = inviteeListSchema.parse(rawInviteeList);
+        setInviteeList(inviteeList.invitations);
       } catch (err) {
         console.error('🩺초대내역 조회 실패:', err);
       } finally {
-        setIsInvitationLoading(false);
+        setIsInviteeLoading(false);
       }
     };
     fetchInvitation();
-  }, [invitationPage]);
+  }, [inviteePage]);
 
   return (
     <div className='flex min-h-screen flex-col gap-6 bg-gray-100 px-12 py-16'>
@@ -148,13 +148,13 @@ const DashboardEdit = () => {
             <div className='flex items-center justify-between p-20 tablet:p-28'>
               <h2 className='flex-grow text-xl font-bold tablet:text-2xl'>초대내역</h2>
               <span className='pr-12 text-xs tablet:pr-16 tablet:text-md'>
-                {totalInvitationPage} 페이지 중 {invitationPage}
+                {totalInviteePage} 페이지 중 {inviteePage}
               </span>
               <Pagination
-                currentPage={invitationPage}
-                isLoading={isInvitationLoading}
-                totalPages={totalInvitationPage}
-                onPageChange={setInvitationPage}
+                currentPage={inviteePage}
+                isLoading={isInviteeLoading}
+                totalPages={totalInviteePage}
+                onPageChange={setInviteePage}
               />
             </div>
             <div className='flex justify-between px-20 pb-10 tablet:px-28'>
@@ -169,7 +169,7 @@ const DashboardEdit = () => {
               </Button>
             </div>
             <ul>
-              {invitationList.map((member, index, arr) => {
+              {inviteeList.map((member, index, arr) => {
                 const { id } = member;
                 const { email } = member.invitee;
                 const isLast = index === arr.length - 1;

--- a/src/pages/dashboards/DashboardEdit.tsx
+++ b/src/pages/dashboards/DashboardEdit.tsx
@@ -1,12 +1,23 @@
+import { useState } from 'react';
+import { useLoaderData } from 'react-router';
+
 import AddBoxIcon from '@/assets/icons/AddBoxIcon';
 import ChevronIcon from '@/assets/icons/ChevronIcon';
 import DotIcon from '@/assets/icons/DotIcon';
+import ColorSelector from '@/components/colorSelector';
 import Button from '@/components/common/button';
 import Pagination from '@/components/pagination';
+import type { DashboardEditLoaderData } from '@/loaders/dashboard/types';
+import type { Invitation } from '@/schemas/invitation';
+import type { Member } from '@/schemas/member';
 
 const DashboardEdit = () => {
-  // 임시 설정
-  const profileImageUrl = '';
+  const initialData = useLoaderData() as DashboardEditLoaderData;
+  const [memberList, setMemberList] = useState<Member[]>(initialData.memberList.members);
+  const [invitationList, setInvitationList] = useState<Invitation[]>(initialData.invitationList.invitations);
+  console.log(memberList);
+  console.log(invitationList);
+
   return (
     <div className='flex min-h-screen flex-col gap-6 bg-gray-100 px-12 py-16'>
       <div className='flex items-center gap-8'>
@@ -30,14 +41,7 @@ const DashboardEdit = () => {
                     type='text'
                   />
                 </label>
-                {/* 버튼, 반복으로 수정 예정 */}
-                <div className='flex gap-8'>
-                  <DotIcon color='var(--color-green)' size={30} />
-                  <DotIcon color='var(--color-purple)' size={30} />
-                  <DotIcon color='var(--color-orange)' size={30} />
-                  <DotIcon color='var(--color-blue)' size={30} />
-                  <DotIcon color='var(--color-pink)' size={30} />
-                </div>
+                <ColorSelector value='color' onChange={() => {}} />
               </div>
             </div>
             <Button className='rounded-lg' size='lg' type='submit' variant='filled'>
@@ -53,19 +57,36 @@ const DashboardEdit = () => {
             </div>
             <div className='px-20 text-md text-gray-400 tablet:px-28 tablet:text-lg'>이름</div>
             <ul>
-              <li className='flex items-center justify-between border-b border-gray-200 px-20 py-12 tablet:px-28 tablet:py-16'>
-                <div className='flex items-center justify-between gap-8'>
-                  {profileImageUrl ? (
-                    <img alt='profile' className='size-34' src={profileImageUrl} />
-                  ) : (
-                    <DotIcon className='tablet:size-38' size={34} />
-                  )}
-                  <span className='text-md tablet:text-lg'>nickname</span>
-                </div>
-                <Button className='w-52 p-0 tablet:w-84 tablet:text-md' size='sm' variant='outlined'>
-                  삭제
-                </Button>
-              </li>
+              {memberList.map((member, index, arr) => {
+                const { userId, nickname, profileImageUrl } = member;
+                const isLast = index === arr.length - 1;
+                return (
+                  <>
+                    <li
+                      key={userId}
+                      className='flex items-center justify-between px-20 py-12 tablet:px-28 tablet:py-16'
+                    >
+                      <div className='flex items-center justify-between gap-8'>
+                        {profileImageUrl ? (
+                          <img alt='profile' className='size-34 rounded-full' src={profileImageUrl} />
+                        ) : (
+                          <DotIcon className='tablet:size-38' size={34} />
+                        )}
+                        <span className='text-md tablet:text-lg'>{nickname}</span>
+                      </div>
+                      <Button
+                        className='w-52 p-0 tablet:w-84 tablet:text-md'
+                        size='sm'
+                        type='button'
+                        variant='outlined'
+                      >
+                        삭제
+                      </Button>
+                    </li>
+                    {!isLast && <div className='border-b border-gray-200' />}
+                  </>
+                );
+              })}
             </ul>
           </section>
           <section className='h-406 max-w-620 rounded-lg bg-white tablet:h-477'>
@@ -87,12 +108,26 @@ const DashboardEdit = () => {
               </Button>
             </div>
             <ul>
-              <li className='flex items-center justify-between border-b border-gray-200 px-20 py-12 tablet:px-28 tablet:py-16'>
-                <div className='text-md tablet:text-lg'>jihyun@naver.com</div>
-                <Button className='w-52 p-0 tablet:w-84 tablet:text-md' size='sm' variant='outlined'>
-                  취소
-                </Button>
-              </li>
+              {invitationList.map((member, index, arr) => {
+                const { id, email } = member.invitee;
+                const isLast = index === arr.length - 1;
+                return (
+                  <>
+                    <li key={id} className='flex items-center justify-between px-20 py-12 tablet:px-28 tablet:py-16'>
+                      <div className='text-md tablet:text-lg'>{email}</div>
+                      <Button
+                        className='w-52 p-0 tablet:w-84 tablet:text-md'
+                        size='sm'
+                        type='button'
+                        variant='outlined'
+                      >
+                        취소
+                      </Button>
+                    </li>
+                    {!isLast && <div className='border-b border-gray-200' />}
+                  </>
+                );
+              })}
             </ul>
           </section>
         </div>

--- a/src/pages/dashboards/DashboardEdit.tsx
+++ b/src/pages/dashboards/DashboardEdit.tsx
@@ -1,20 +1,24 @@
 import { useEffect, useRef, useState } from 'react';
-import { useLoaderData } from 'react-router';
+import { useLoaderData, useParams } from 'react-router';
 
 import { getInvitationList } from '@/apis/dashboard';
 import { getMemberList } from '@/apis/member';
 import AddBoxIcon from '@/assets/icons/AddBoxIcon';
 import ChevronIcon from '@/assets/icons/ChevronIcon';
-import Avatar from '@/components/Avatar';
 import ColorSelector from '@/components/colorSelector';
 import Button from '@/components/common/button';
+import Invitations from '@/components/dashboardEdit/invitations';
+import Members from '@/components/dashboardEdit/members';
 import Pagination from '@/components/pagination';
 import type { DashboardEditLoaderData } from '@/loaders/dashboard/types';
 import { invitationListSchema } from '@/schemas/dashboard';
 import type { Invitation } from '@/schemas/invitation';
-import { type Member, memberListResponseSchema } from '@/schemas/member';
+import type { Member } from '@/schemas/member';
+import { memberListResponseSchema } from '@/schemas/member';
 
 const DashboardEdit = () => {
+  const { dashboardId } = useParams();
+  const dashboardIdNumber = Number(dashboardId);
   const initialData = useLoaderData() as DashboardEditLoaderData;
   const [memberList, setMemberList] = useState<Member[]>(initialData.memberList.members);
   const [memberPage, setMemberPage] = useState<number>(1);
@@ -40,11 +44,11 @@ const DashboardEdit = () => {
       if (isMemberLoading) return;
       setIsMemberLoading(true);
       try {
-        const rawMemberList = await getMemberList({ dashboardId: 15131, size: 4, page: memberPage });
+        const rawMemberList = await getMemberList({ dashboardId: dashboardIdNumber, size: 4, page: memberPage });
         const memberList = memberListResponseSchema.parse(rawMemberList);
         setMemberList(memberList.members);
-      } catch (error) {
-        console.error(error); // 에러 미구현
+      } catch (err) {
+        console.error('🩺구성원 조회 실패:', err);
       } finally {
         setIsMemberLoading(false);
       }
@@ -64,11 +68,15 @@ const DashboardEdit = () => {
       if (isInvitationLoading) return;
       setIsInvitationLoading(true);
       try {
-        const rawInvitationList = await getInvitationList({ dashboardId: 15131, size: 5, page: invitationPage });
+        const rawInvitationList = await getInvitationList({
+          dashboardId: dashboardIdNumber,
+          size: 5,
+          page: invitationPage,
+        });
         const invitationList = invitationListSchema.parse(rawInvitationList);
         setInvitationList(invitationList.invitations);
-      } catch (error) {
-        console.error(error); // 에러 미구현
+      } catch (err) {
+        console.error('🩺초대내역 조회 실패:', err);
       } finally {
         setIsInvitationLoading(false);
       }
@@ -111,7 +119,7 @@ const DashboardEdit = () => {
           </section>
           <section className='flex h-337 max-w-620 flex-col rounded-lg bg-white tablet:h-404'>
             <div className='flex items-center justify-between p-20 tablet:p-28'>
-              <h2 className='text-xl font-bold tablet:text-2xl'>구성원</h2>
+              <h2 className='flex-grow text-xl font-bold tablet:text-2xl'>구성원</h2>
               <span className='pr-12 text-xs tablet:pr-16 tablet:text-md'>
                 {totalMemberPage} 페이지 중 {memberPage}
               </span>
@@ -128,33 +136,14 @@ const DashboardEdit = () => {
                 const { userId, nickname, profileImageUrl } = member;
                 const isLast = index === arr.length - 1;
                 return (
-                  <>
-                    <li
-                      key={userId}
-                      className='flex items-center justify-between px-20 py-12 tablet:px-28 tablet:py-16'
-                    >
-                      <div className='flex items-center justify-between gap-8'>
-                        <Avatar nickname={nickname} src={profileImageUrl ?? undefined} />
-                        <span className='text-md tablet:text-lg'>{nickname}</span>
-                      </div>
-                      <Button
-                        className='w-52 p-0 tablet:w-84 tablet:text-md'
-                        size='sm'
-                        type='button'
-                        variant='outlined'
-                      >
-                        삭제
-                      </Button>
-                    </li>
-                    {!isLast && <div className='border-b border-gray-200' />}
-                  </>
+                  <Members key={userId} isLast={isLast} nickname={nickname} profileImg={profileImageUrl ?? undefined} />
                 );
               })}
             </ul>
           </section>
           <section className='h-406 max-w-620 rounded-lg bg-white tablet:h-477'>
             <div className='flex items-center justify-between p-20 tablet:p-28'>
-              <h2 className='text-xl font-bold tablet:text-2xl'>초대내역</h2>
+              <h2 className='flex-grow text-xl font-bold tablet:text-2xl'>초대내역</h2>
               <span className='pr-12 text-xs tablet:pr-16 tablet:text-md'>
                 {totalInvitationPage} 페이지 중 {invitationPage}
               </span>
@@ -178,24 +167,10 @@ const DashboardEdit = () => {
             </div>
             <ul>
               {invitationList.map((member, index, arr) => {
-                const { id, email } = member.invitee;
+                const { id } = member;
+                const { email } = member.invitee;
                 const isLast = index === arr.length - 1;
-                return (
-                  <>
-                    <li key={id} className='flex items-center justify-between px-20 py-12 tablet:px-28 tablet:py-16'>
-                      <div className='text-md tablet:text-lg'>{email}</div>
-                      <Button
-                        className='w-52 p-0 tablet:w-84 tablet:text-md'
-                        size='sm'
-                        type='button'
-                        variant='outlined'
-                      >
-                        취소
-                      </Button>
-                    </li>
-                    {!isLast && <div className='border-b border-gray-200' />}
-                  </>
-                );
+                return <Invitations key={id} email={email} isLast={isLast} />;
               })}
             </ul>
           </section>

--- a/src/schemas/dashboard.ts
+++ b/src/schemas/dashboard.ts
@@ -88,7 +88,7 @@ export const createTodoSchema = z.object({
  * To server
  * @description 대시보드 초대 목록 조회 요청 시 사용하는 쿼리 파라미터의 유효성을 검사하는 스키마
  */
-export const invitationListParamsSchema = z.object({
+export const inviteeListParamsSchema = z.object({
   dashboardId: z.number().int().positive(),
   page: z.number().int().positive().optional(),
   size: z.number().int().positive().optional(),
@@ -98,7 +98,7 @@ export const invitationListParamsSchema = z.object({
  * From server
  * @description 대시보드 초대 목록 응답 데이터의 유효성을 검사하는 스키마
  */
-export const invitationListSchema = z.object({
+export const inviteeListSchema = z.object({
   invitations: z.array(invitationSchema),
   totalCount: z.number().int().positive(),
 });
@@ -110,5 +110,5 @@ export type DashboardListParams = z.infer<typeof dashboardListParamsSchema>;
 export type DashboardListData = z.infer<typeof dashboardListResponseSchema>;
 export type Dashboard = z.infer<typeof dashboardSchema>;
 export type CreateTodoType = z.infer<typeof createTodoSchema>;
-export type InvitationListParams = z.infer<typeof invitationListParamsSchema>;
-export type InvitationList = z.infer<typeof invitationListSchema>;
+export type InviteeListParams = z.infer<typeof inviteeListParamsSchema>;
+export type InviteeList = z.infer<typeof inviteeListSchema>;

--- a/src/schemas/dashboard.ts
+++ b/src/schemas/dashboard.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import UI_ERRORS from '@/constants/errors/uiErrors';
+import { invitationSchema } from '@/schemas/invitation';
 
 /**
  * @description 페이지네이션 방식 유효성 검사를 위한 스키마
@@ -82,6 +83,25 @@ export const createTodoSchema = z.object({
   imageUrl: z.any().optional(),
 });
 
+/**
+ * To server
+ * @description 대시보드 초대 목록 조회 요청 시 사용하는 쿼리 파라미터의 유효성을 검사하는 스키마
+ */
+export const invitationListParamsSchema = z.object({
+  dashboardId: z.number().int().positive(),
+  page: z.number().int().positive().optional(),
+  size: z.number().int().positive().optional(),
+});
+
+/**
+ * From server
+ * @description 대시보드 초대 목록 응답 데이터의 유효성을 검사하는 스키마
+ */
+export const invitationListSchema = z.object({
+  invitations: z.array(invitationSchema),
+  totalCount: z.number().int().positive(),
+});
+
 export type NavigationMethod = z.infer<typeof navigationMethodSchema>;
 export type CreateDashboardInput = z.infer<typeof createDashboardSchema>;
 export type UpdateDashboardInput = z.infer<typeof updateDashboardSchema>;
@@ -89,3 +109,5 @@ export type DashboardListParams = z.infer<typeof dashboardListParamsSchema>;
 export type DashboardListData = z.infer<typeof dashboardListResponseSchema>;
 export type Dashboard = z.infer<typeof dashboardSchema>;
 export type CreateTodoType = z.infer<typeof createTodoSchema>;
+export type InvitationListParams = z.infer<typeof invitationListParamsSchema>;
+export type InvitationList = z.infer<typeof invitationListSchema>;

--- a/src/schemas/dashboard.ts
+++ b/src/schemas/dashboard.ts
@@ -100,7 +100,7 @@ export const inviteeListParamsSchema = z.object({
  */
 export const inviteeListSchema = z.object({
   invitations: z.array(invitationSchema),
-  totalCount: z.number().int().positive(),
+  totalCount: z.number().int(),
 });
 
 export type NavigationMethod = z.infer<typeof navigationMethodSchema>;


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- 이슈 번호 #127 

## ✨ 요약
- 대시보드 수정페이지 페이지네이션 구현

## 📌 주요 변경 사항
- 대시보드 수정페이지 초기 데이터 연결
- 구성원 목록 페이지네이션 (컴포넌트 분리)
- 초대내역 목록 페이지네이션 (컴포넌트 분리)

## ✅ 체크리스트

<!-- 체크리스트 내용을 수정하고 싶으면 회의 때 얘기부탁드려요. -->

- [x] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다.
  - [x] 구현 기간에 맞는 이슈에서 서브이슈로 등록했습니다.
  - [x] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
  - [x] PR 사이드 탭에서는 Projects을 등록 하지않았습니다.
- [x] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [x] 변경사항을 충분히 테스트 했습니다.
- [x] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [x] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)
- 오너는 삭제버튼 대신 왕관표시
<img width="637" alt="스크린샷 2025-06-20 오후 1 31 44" src="https://github.com/user-attachments/assets/4833469d-4fef-422d-a491-4eda3b20c651" />

https://github.com/user-attachments/assets/9c30c120-9eaf-4593-8917-769b255a05fc


## ❓무슨 문제가 발생했나요 ?

## 💬 논의 사항

## 💬 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 대시보드 초대자 목록 조회 API가 추가되었습니다.
  - 멤버와 초대자 각각을 위한 리스트 컴포넌트가 추가되었습니다.
  - 대시보드 편집 페이지에서 멤버 및 초대자 목록을 동적 페이지네이션과 함께 실시간으로 관리할 수 있습니다.
  - 대시보드 이름 색상 선택 기능이 개선되었습니다.

- **버그 수정**
  - 일부 레이아웃 및 스타일 이슈가 수정되었습니다.
  - 랜딩 페이지 문법 오류가 해결되었습니다.

- **리팩터**
  - 대시보드 편집 페이지의 데이터 로딩 및 상태 관리 방식이 개선되었습니다.
  - 대시보드 편집 데이터 로더가 견고해지고 오류 처리가 강화되었습니다.

- **문서화**
  - 타입 및 인터페이스에 대한 설명이 추가되었습니다.
  - 대시보드 초대자 관련 스키마 및 타입이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->