### PR TITLE
✨Feat: 내 대시보드 페이지 수락/거절 기능 추가 + 새 대시보드 만들기 버튼 기능 추가

### DIFF
--- a/src/components/invitationItem/index.tsx
+++ b/src/components/invitationItem/index.tsx
@@ -6,10 +6,12 @@ import type { InvitationItemProps } from './types';
  * 초대받은 대시보드 목록의 개별 항목을 렌더링하는 컴포넌트입니다.
  * 각 항목은 대시보드 이름, 초대자 정보, 그리고 초대를 수락하거나 거절하는 버튼을 포함합니다.
  *
+ * @param {number} id - 초대받은 대시보드의 id값 입니다.
  * @param {string} dashboardTitle - 초대받은 대시보드의 제목입니다.
  * @param {string} inviterNickname - 초대를 보낸 사용자의 닉네임입니다.
+ * @param {(id: number, response: boolean) => Promise<void>} onResponse - 수락/거절 버튼을 눌렀을 때 발생하는 함수입니다.
  */
-const InvitationItem = ({ dashboardTitle, inviterNickname }: InvitationItemProps) => {
+const InvitationItem = ({ id, dashboardTitle, inviterNickname, onResponse }: InvitationItemProps) => {
   return (
     <>
       <div className='flex gap-24 text-md font-normal tablet:w-3/10 tablet:text-lg'>
@@ -21,10 +23,15 @@ const InvitationItem = ({ dashboardTitle, inviterNickname }: InvitationItemProps
         <span>{inviterNickname}</span>
       </div>
       <div className='mt-14 flex justify-center gap-10 tablet:mt-0 tablet:w-4/10'>
-        <Button className='w-full tablet:w-72 tablet:text-md pc:w-84' size='sm'>
+        <Button className='w-full tablet:w-72 tablet:text-md pc:w-84' size='sm' onClick={() => onResponse(id, true)}>
           수락
         </Button>
-        <Button className='w-full tablet:w-72 tablet:text-md pc:w-84' size='sm' variant='outlined'>
+        <Button
+          className='w-full tablet:w-72 tablet:text-md pc:w-84'
+          size='sm'
+          variant='outlined'
+          onClick={() => onResponse(id, false)}
+        >
           거절
         </Button>
       </div>

--- a/src/components/invitationItem/types/index.ts
+++ b/src/components/invitationItem/types/index.ts
@@ -1,6 +1,8 @@
 import type { Invitation } from '@/schemas/invitation';
 
 export interface InvitationItemProps {
+  id: Invitation['id'];
   dashboardTitle: Invitation['dashboard']['title'];
   inviterNickname: Invitation['inviter']['nickname'];
+  onResponse: (id: number, response: boolean) => Promise<void>;
 }

--- a/src/pages/dashboards/DashboardList.tsx
+++ b/src/pages/dashboards/DashboardList.tsx
@@ -8,6 +8,7 @@ import NoInvitation from '@/assets/icons/NoInvitationIcon';
 import Button from '@/components/common/button';
 import DashboardItem from '@/components/dashboardItem';
 import InvitationItem from '@/components/invitationItem';
+import CreateDashboard from '@/components/modal/CreateDashboard';
 import Pagination from '@/components/pagination';
 import Search from '@/components/search';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
@@ -33,6 +34,8 @@ const DashboardList = () => {
   const [isInvitationLoading, setIsInvitationLoading] = useState<boolean>(false);
   const [cursorId, setCursorId] = useState<number | null>(initialInvitationData.invitationList.cursorId);
   const [searchValue, setSearchValue] = useState<string>('');
+
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   const isInitialRender = useRef(true);
 
@@ -120,6 +123,7 @@ const DashboardList = () => {
                 className='h-58 w-full gap-12 rounded-lg text-md font-semibold text-gray-700 tablet:h-68 tablet:text-lg'
                 size='none'
                 variant='outlined'
+                onClick={() => setIsModalOpen(true)}
               >
                 새로운 대시보드 <AddIcon className='size-20 rounded-sm bg-cream p-5 tablet:size-22 tablet:p-6' />
               </Button>
@@ -188,6 +192,7 @@ const DashboardList = () => {
           <div ref={infiniteScrollRef} />
         </div>
       </div>
+      <CreateDashboard isModalOpen={isModalOpen} toggleModal={() => setIsModalOpen((...prev) => !prev)} />
     </div>
   );
 };


### PR DESCRIPTION
## 🧩 관련 이슈 번호

- 이슈 번호 #197 

## ✨ 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->
수락/거절 기능을 구현했습니다.
새 대시보드 만들기 버트을 누르면 모달이 나옵니다.
중간에 key값을 index로 바꾼 부분이 있습니다. 서버의 설계 상 같은 대시보드가 있을 수 있어서 id값으로 key값을 하면 중복될 수 있어서 했습니다. data가 무조건 맨 뒤에 들어올 거 같아서 index로 했는데 지금 다시 생각해보니 무조건 맨 뒤가 아니였네요.. 이 부분 다시 수정하겠습니다.
## 📌 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->

## ✅ 체크리스트

<!-- 체크리스트 내용을 수정하고 싶으면 회의 때 얘기부탁드려요. -->

- [ ] PR 하기 전에 이슈에서 빼먹은건 없는지 확인했습니다.
  - [ ] 구현 기간에 맞는 이슈에서 서브이슈로 등록했습니다.
  - [ ] 라벨 및 마일스톤을 사이드 탭에서 등록했습니다.
  - [ ] PR 사이드 탭에서는 Projects을 등록 하지않았습니다.
- [ ] PR을 보내는 브랜치가 올바른지 확인했습니다.
- [ ] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했습니다.
- [ ] 변경사항을 충분히 테스트 했습니다.
- [ ] (함수를 구현 했을 때) JSDoc을 양식에 맞춰서 작성했습니다.
- [ ] 컨벤션에 맞게 구현했습니다.

## 📷 UI 변경 사항 (선택)

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

| 구현 전   | 구현 후   |
| --------- | --------- |
| UI 이미지 | UI 이미지 |

## ❓무슨 문제가 발생했나요 ?

## 💬 논의 사항

<!-- 논의하고 싶은 사항을 적어 주시고, 토론이 필요하시면 토론 탭에 추가 부탁드립니다. -->

## 💬 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주면 감사합니다. -->
